### PR TITLE
test: add unit coverage

### DIFF
--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1,0 +1,44 @@
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestNewClientValidation(t *testing.T) {
+	cases := []struct {
+		name     string
+		endpoint string
+		apiKey   string
+		model    string
+	}{
+		{name: "empty endpoint", endpoint: "", apiKey: "key", model: "model"},
+		{name: "empty api key", endpoint: "https://example.com", apiKey: "", model: "model"},
+		{name: "empty model", endpoint: "https://example.com", apiKey: "key", model: ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			client, err := NewClient(tc.endpoint, tc.apiKey, tc.model)
+			require.Error(t, err)
+			require.Nil(t, client)
+		})
+	}
+}
+
+func TestNewClientSuccess(t *testing.T) {
+	client, err := NewClient("https://example.com", "key", "model")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+}
+
+func TestCreateResponseEmptyInput(t *testing.T) {
+	client, err := NewClient("https://example.com", "key", "model")
+	require.NoError(t, err)
+	_, err = client.CreateResponse(context.Background(), "", nil, nil, responses.ResponseNewParamsToolChoiceUnion{}, false, nil)
+	require.Error(t, err)
+}

--- a/internal/llm/extract_test.go
+++ b/internal/llm/extract_test.go
@@ -1,0 +1,62 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestExtractToolCallsEmpty(t *testing.T) {
+	resp := &responses.Response{}
+	calls := ExtractToolCalls(resp)
+	require.Nil(t, calls)
+}
+
+func TestExtractToolCallsMessageOnly(t *testing.T) {
+	resp := &responses.Response{
+		Output: []responses.ResponseOutputItemUnion{mustOutputItem(t, `{"id":"msg-1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]}`)},
+	}
+	calls := ExtractToolCalls(resp)
+	require.Nil(t, calls)
+}
+
+func TestExtractToolCallsFunctionCalls(t *testing.T) {
+	resp := &responses.Response{
+		Output: []responses.ResponseOutputItemUnion{
+			mustOutputItem(t, `{"type":"function_call","call_id":"call-1","name":"do","arguments":"{\"value\":1}"}`),
+			mustOutputItem(t, `{"type":"function_call","call_id":"call-2","name":"run","arguments":"{\"value\":2}"}`),
+		},
+	}
+
+	calls := ExtractToolCalls(resp)
+	require.Len(t, calls, 2)
+	require.Equal(t, "call-1", calls[0].ID)
+	require.Equal(t, "do", calls[0].Name)
+	require.Equal(t, json.RawMessage(`{"value":1}`), calls[0].Arguments)
+	require.Equal(t, "call-2", calls[1].ID)
+	require.Equal(t, "run", calls[1].Name)
+	require.Equal(t, json.RawMessage(`{"value":2}`), calls[1].Arguments)
+}
+
+func TestExtractToolCallsMixedItems(t *testing.T) {
+	resp := &responses.Response{
+		Output: []responses.ResponseOutputItemUnion{
+			mustOutputItem(t, `{"id":"msg-1","type":"message","role":"assistant","status":"completed","content":[{"type":"output_text","text":"hello"}]}`),
+			mustOutputItem(t, `{"type":"function_call","call_id":"call-1","name":"do","arguments":"{\"value\":1}"}`),
+		},
+	}
+
+	calls := ExtractToolCalls(resp)
+	require.Len(t, calls, 1)
+	require.Equal(t, json.RawMessage(`{"value":1}`), calls[0].Arguments)
+}
+
+func mustOutputItem(t *testing.T, payload string) responses.ResponseOutputItemUnion {
+	t.Helper()
+	var item responses.ResponseOutputItemUnion
+	require.NoError(t, json.Unmarshal([]byte(payload), &item))
+	return item
+}

--- a/internal/llm/messages_test.go
+++ b/internal/llm/messages_test.go
@@ -1,0 +1,73 @@
+package llm
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agynio/agn-cli/internal/message"
+	"github.com/openai/openai-go/v3/responses"
+)
+
+func TestMessagesToInputMappings(t *testing.T) {
+	toolCalls := []message.ToolCall{
+		{ID: "call-1", Name: "tool-one", Arguments: json.RawMessage(`{"path":"/tmp"}`)},
+		{ID: "call-2", Name: "tool-two", Arguments: json.RawMessage(`{"verbose":true}`)},
+	}
+	output := message.ToolCallOutput{ToolCallID: "call-1", ToolName: "tool-one", Output: "ok"}
+
+	inputs, err := MessagesToInput([]message.Message{
+		message.NewSystemMessage("system"),
+		message.NewSummaryMessage("summary"),
+		message.NewHumanMessage("human"),
+		message.NewAIMessage("assistant"),
+		message.NewToolCallMessage(toolCalls),
+		message.NewToolCallOutputMessage(output),
+	})
+	require.NoError(t, err)
+	require.Len(t, inputs, 7)
+
+	requireMessageInput(t, inputs[0], responses.EasyInputMessageRoleDeveloper, "system")
+	requireMessageInput(t, inputs[1], responses.EasyInputMessageRoleDeveloper, "summary")
+	requireMessageInput(t, inputs[2], responses.EasyInputMessageRoleUser, "human")
+	requireMessageInput(t, inputs[3], responses.EasyInputMessageRoleAssistant, "assistant")
+	requireFunctionCallInput(t, inputs[4], toolCalls[0])
+	requireFunctionCallInput(t, inputs[5], toolCalls[1])
+	requireFunctionCallOutputInput(t, inputs[6], output)
+}
+
+func TestMessagesToInputResponseMessageError(t *testing.T) {
+	_, err := MessagesToInput([]message.Message{message.NewResponseMessage("raw")})
+	require.Error(t, err)
+}
+
+func TestMessagesToInputEmpty(t *testing.T) {
+	inputs, err := MessagesToInput(nil)
+	require.NoError(t, err)
+	require.Empty(t, inputs)
+}
+
+func requireMessageInput(t *testing.T, item responses.ResponseInputItemUnionParam, role responses.EasyInputMessageRole, text string) {
+	t.Helper()
+	require.NotNil(t, item.OfMessage)
+	require.Equal(t, role, item.OfMessage.Role)
+	require.True(t, item.OfMessage.Content.OfString.Valid())
+	require.Equal(t, text, item.OfMessage.Content.OfString.Value)
+}
+
+func requireFunctionCallInput(t *testing.T, item responses.ResponseInputItemUnionParam, call message.ToolCall) {
+	t.Helper()
+	require.NotNil(t, item.OfFunctionCall)
+	require.Equal(t, call.ID, item.OfFunctionCall.CallID)
+	require.Equal(t, call.Name, item.OfFunctionCall.Name)
+	require.Equal(t, string(call.Arguments), item.OfFunctionCall.Arguments)
+}
+
+func requireFunctionCallOutputInput(t *testing.T, item responses.ResponseInputItemUnionParam, output message.ToolCallOutput) {
+	t.Helper()
+	require.NotNil(t, item.OfFunctionCallOutput)
+	require.Equal(t, output.ToolCallID, item.OfFunctionCallOutput.CallID)
+	require.True(t, item.OfFunctionCallOutput.Output.OfString.Valid())
+	require.Equal(t, output.Output, item.OfFunctionCallOutput.Output.OfString.Value)
+}

--- a/internal/loop/loop_test.go
+++ b/internal/loop/loop_test.go
@@ -1,0 +1,109 @@
+package loop
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLoopValidation(t *testing.T) {
+	_, err := NewLoop(nil, StageLoad, 1)
+	require.Error(t, err)
+
+	_, err = NewLoop(map[StageID]Stage{StageLoad: {}}, "", 1)
+	require.Error(t, err)
+
+	_, err = NewLoop(map[StageID]Stage{StageLoad: {}}, StageLoad, 0)
+	require.Error(t, err)
+}
+
+func TestLoopRunPipeline(t *testing.T) {
+	var visited []StageID
+	stages := map[StageID]Stage{
+		"start": {
+			Reducer: func(ctx context.Context, state *State) error {
+				visited = append(visited, "start")
+				return nil
+			},
+			Next: "middle",
+		},
+		"middle": {
+			Reducer: func(ctx context.Context, state *State) error {
+				visited = append(visited, "middle")
+				return nil
+			},
+			Next: StageDone,
+		},
+	}
+	loop, err := NewLoop(stages, "start", 5)
+	require.NoError(t, err)
+	require.NoError(t, loop.Run(context.Background(), &State{}))
+	require.Equal(t, []StageID{"start", "middle"}, visited)
+}
+
+func TestLoopRunUnknownStage(t *testing.T) {
+	loop, err := NewLoop(map[StageID]Stage{StageLoad: {}}, "missing", 2)
+	require.NoError(t, err)
+	err = loop.Run(context.Background(), &State{})
+	require.Error(t, err)
+}
+
+func TestLoopRunMaxSteps(t *testing.T) {
+	loop, err := NewLoop(map[StageID]Stage{
+		"loop": {Next: "loop"},
+	}, "loop", 2)
+	require.NoError(t, err)
+	err = loop.Run(context.Background(), &State{})
+	require.Error(t, err)
+}
+
+func TestLoopRunContextCanceled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	loop, err := NewLoop(map[StageID]Stage{
+		"start": {
+			Reducer: func(ctx context.Context, state *State) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+			Next: StageDone,
+		},
+	}, "start", 1)
+	require.NoError(t, err)
+	err = loop.Run(ctx, &State{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+func TestLoopRunRouterBranching(t *testing.T) {
+	stages := map[StageID]Stage{
+		"route": {
+			Router: func(ctx context.Context, state *State) (StageID, error) {
+				if state.ForceToolCall {
+					return "tool", nil
+				}
+				return "save", nil
+			},
+		},
+		"tool": {
+			Reducer: func(ctx context.Context, state *State) error {
+				state.LastAssistant = "tool"
+				return nil
+			},
+			Next: StageDone,
+		},
+		"save": {
+			Reducer: func(ctx context.Context, state *State) error {
+				state.LastAssistant = "save"
+				return nil
+			},
+			Next: StageDone,
+		},
+	}
+	loop, err := NewLoop(stages, "route", 3)
+	require.NoError(t, err)
+
+	state := &State{ForceToolCall: true}
+	require.NoError(t, loop.Run(context.Background(), state))
+	require.Equal(t, "tool", state.LastAssistant)
+}

--- a/internal/mcp/client_test.go
+++ b/internal/mcp/client_test.go
@@ -1,0 +1,156 @@
+package mcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientSequentialRequests(t *testing.T) {
+	client, reqReader, respWriter, cleanup := setupClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	var tools []Tool
+	var listErr error
+	listDone := make(chan struct{})
+	go func() {
+		tools, listErr = client.ListTools(ctx)
+		close(listDone)
+	}()
+
+	listReq := readRequest(t, reqReader)
+	require.Equal(t, "2.0", listReq.JSONRPC)
+	require.Equal(t, int64(1), listReq.ID)
+	require.Equal(t, "tools/list", listReq.Method)
+
+	expectedTools := []Tool{{
+		Name:        "read",
+		Description: "Read",
+		InputSchema: json.RawMessage(`{"type":"object"}`),
+	}}
+	writeResponse(t, respWriter, listReq.ID, map[string]any{"tools": expectedTools}, nil)
+	<-listDone
+	require.NoError(t, listErr)
+	require.Equal(t, expectedTools, tools)
+
+	var result ToolResult
+	var callErr error
+	callDone := make(chan struct{})
+	go func() {
+		result, callErr = client.CallTool(ctx, ToolCall{
+			ID:        "call-1",
+			Name:      "read",
+			Arguments: json.RawMessage(`{"path":"/tmp"}`),
+		})
+		close(callDone)
+	}()
+
+	callReq := readRequest(t, reqReader)
+	require.Equal(t, "2.0", callReq.JSONRPC)
+	require.Equal(t, int64(2), callReq.ID)
+	require.Equal(t, "tools/call", callReq.Method)
+
+	params, ok := callReq.Params.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "read", params["name"])
+	args, ok := params["arguments"].(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "/tmp", args["path"])
+
+	writeResponse(t, respWriter, callReq.ID, ToolResult{Content: "ok"}, nil)
+	<-callDone
+	require.NoError(t, callErr)
+	require.Equal(t, ToolResult{Content: "ok"}, result)
+}
+
+func TestClientListToolsError(t *testing.T) {
+	client, reqReader, respWriter, cleanup := setupClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	var err error
+	done := make(chan struct{})
+	go func() {
+		_, err = client.ListTools(ctx)
+		close(done)
+	}()
+
+	listReq := readRequest(t, reqReader)
+	writeResponse(t, respWriter, listReq.ID, nil, &rpcError{Code: -32001, Message: "boom"})
+	<-done
+	require.Error(t, err)
+}
+
+func TestClientCallToolEmptyContent(t *testing.T) {
+	client, reqReader, respWriter, cleanup := setupClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	var err error
+	done := make(chan struct{})
+	go func() {
+		_, err = client.CallTool(ctx, ToolCall{Name: "read", Arguments: json.RawMessage(`{"path":"/tmp"}`)})
+		close(done)
+	}()
+
+	callReq := readRequest(t, reqReader)
+	writeResponse(t, respWriter, callReq.ID, ToolResult{Content: ""}, nil)
+	<-done
+	require.Error(t, err)
+}
+
+func TestNewProcessClientValidation(t *testing.T) {
+	client, err := NewProcessClient(context.Background(), "  ")
+	require.Error(t, err)
+	require.Nil(t, client)
+}
+
+func setupClient(t *testing.T) (*Client, *bufio.Reader, io.WriteCloser, func()) {
+	t.Helper()
+	serverToClientR, serverToClientW := io.Pipe()
+	clientToServerR, clientToServerW := io.Pipe()
+	client := NewClient(serverToClientR, clientToServerW, clientToServerW)
+	reader := bufio.NewReader(clientToServerR)
+	cleanup := func() {
+		_ = serverToClientW.Close()
+		_ = clientToServerW.Close()
+		_ = clientToServerR.Close()
+		_ = serverToClientR.Close()
+		_ = client.Close()
+	}
+	return client, reader, serverToClientW, cleanup
+}
+
+func readRequest(t *testing.T, reader *bufio.Reader) request {
+	t.Helper()
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	line = strings.TrimSpace(line)
+	var req request
+	require.NoError(t, json.Unmarshal([]byte(line), &req))
+	return req
+}
+
+func writeResponse(t *testing.T, writer io.Writer, id int64, result any, errObj *rpcError) {
+	t.Helper()
+	resp := response{JSONRPC: "2.0", ID: json.RawMessage(strconv.FormatInt(id, 10))}
+	if errObj != nil {
+		resp.Error = errObj
+	} else {
+		data, err := json.Marshal(result)
+		require.NoError(t, err)
+		resp.Result = data
+	}
+	payload, err := json.Marshal(resp)
+	require.NoError(t, err)
+	payload = append(payload, '\n')
+	_, err = writer.Write(payload)
+	require.NoError(t, err)
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agynio/agn-cli/internal/loop"
+)
+
+func TestServeErrorResponses(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		expectedID string
+		code       int
+		message    string
+	}{
+		{
+			name:       "parse error",
+			input:      "not-json",
+			expectedID: "null",
+			code:       -32700,
+			message:    "parse error",
+		},
+		{
+			name:       "invalid request missing method",
+			input:      `{"jsonrpc":"2.0","id":1,"method":""}`,
+			expectedID: "1",
+			code:       -32600,
+			message:    "invalid request",
+		},
+		{
+			name:       "invalid request missing id",
+			input:      `{"jsonrpc":"2.0","method":"agent.turn","params":{}}`,
+			expectedID: "null",
+			code:       -32600,
+			message:    "invalid request",
+		},
+		{
+			name:       "method not found",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"agent.unknown","params":{}}`,
+			expectedID: "1",
+			code:       -32601,
+			message:    "method not found",
+		},
+		{
+			name:       "invalid params",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"agent.turn","params":"nope"}`,
+			expectedID: "1",
+			code:       -32602,
+			message:    "invalid params",
+		},
+		{
+			name:       "prompt required",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"agent.turn","params":{"prompt":" "}}`,
+			expectedID: "1",
+			code:       -32602,
+			message:    "prompt is required",
+		},
+		{
+			name:       "request id required",
+			input:      `{"jsonrpc":"2.0","id":1,"method":"agent.cancel","params":{"request_id":" "}}`,
+			expectedID: "1",
+			code:       -32602,
+			message:    "request_id is required",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := runServerRequest(t, tc.input)
+			require.Equal(t, jsonRPCVersion, resp.JSONRPC)
+			require.NotNil(t, resp.Error)
+			require.Equal(t, tc.code, resp.Error.Code)
+			require.Equal(t, tc.message, resp.Error.Message)
+			require.Equal(t, tc.expectedID, string(resp.ID))
+		})
+	}
+}
+
+func runServerRequest(t *testing.T, input string) response {
+	t.Helper()
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+	ctx, cancel := context.WithCancel(context.Background())
+	server := New(&loop.Agent{})
+	done := make(chan error, 1)
+	go func() {
+		done <- server.Serve(ctx, inR, outW)
+	}()
+
+	_, err := io.WriteString(inW, input+"\n")
+	require.NoError(t, err)
+
+	scanner := bufio.NewScanner(outR)
+	require.True(t, scanner.Scan())
+	var resp response
+	require.NoError(t, json.Unmarshal(scanner.Bytes(), &resp))
+
+	cancel()
+	_ = inW.Close()
+	require.ErrorIs(t, <-done, context.Canceled)
+	_ = outR.Close()
+	_ = outW.Close()
+	return resp
+}

--- a/internal/state/local_test.go
+++ b/internal/state/local_test.go
@@ -1,0 +1,162 @@
+package state
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agynio/agn-cli/internal/message"
+)
+
+func TestNewLocalStoreValidation(t *testing.T) {
+	store, err := NewLocalStore("")
+	require.Error(t, err)
+	require.Nil(t, store)
+}
+
+func TestLocalStoreSaveLoadRoundTrip(t *testing.T) {
+	store := newLocalStore(t)
+	ctx := context.Background()
+	createdAt := time.Date(2024, 10, 12, 8, 0, 0, 0, time.UTC)
+	conversation := Conversation{
+		ID: "conv-1",
+		Messages: []MessageRecord{
+			{
+				ID:         "msg-1",
+				CreatedAt:  createdAt,
+				TokenCount: 4,
+				Message:    message.NewHumanMessage("hello"),
+			},
+			{
+				ID:         "msg-2",
+				CreatedAt:  createdAt.Add(time.Minute),
+				TokenCount: 3,
+				Message:    message.NewAIMessage("world"),
+			},
+		},
+	}
+	before := time.Now().UTC()
+	require.NoError(t, store.Save(ctx, conversation))
+
+	loaded, err := store.Load(ctx, conversation.ID)
+	require.NoError(t, err)
+	require.Equal(t, conversation.ID, loaded.ID)
+	require.Equal(t, conversation.Messages, loaded.Messages)
+	require.False(t, loaded.UpdatedAt.IsZero())
+	require.True(t, loaded.UpdatedAt.Equal(before) || loaded.UpdatedAt.After(before))
+}
+
+func TestLocalStoreLoadMissing(t *testing.T) {
+	store := newLocalStore(t)
+	ctx := context.Background()
+	conv, err := store.Load(ctx, "missing")
+	require.NoError(t, err)
+	require.Equal(t, "missing", conv.ID)
+	require.Empty(t, conv.Messages)
+}
+
+func TestLocalStoreLoadSaveEmptyID(t *testing.T) {
+	store := newLocalStore(t)
+	ctx := context.Background()
+	_, err := store.Load(ctx, "")
+	require.Error(t, err)
+	returnErr := store.Save(ctx, Conversation{})
+	require.Error(t, returnErr)
+}
+
+func TestLocalStoreLoadMismatchedID(t *testing.T) {
+	store := newLocalStore(t)
+	ctx := context.Background()
+	writePersistedConversation(t, store.basePath, "expected", persistedConversation{
+		ID:        "other",
+		UpdatedAt: time.Now().UTC(),
+		Messages:  []persistedMessage{persistedMessageFixture(t)},
+	})
+
+	_, err := store.Load(ctx, "expected")
+	require.Error(t, err)
+}
+
+func TestLocalStoreLoadZeroTokenCount(t *testing.T) {
+	store := newLocalStore(t)
+	ctx := context.Background()
+	msg := persistedMessageFixture(t)
+	msg.TokenCount = 0
+	writePersistedConversation(t, store.basePath, "conv-1", persistedConversation{
+		ID:        "conv-1",
+		UpdatedAt: time.Now().UTC(),
+		Messages:  []persistedMessage{msg},
+	})
+
+	_, err := store.Load(ctx, "conv-1")
+	require.Error(t, err)
+}
+
+func TestLocalStoreLoadCorruptJSON(t *testing.T) {
+	store := newLocalStore(t)
+	path := filepath.Join(store.basePath, "conv-1.json")
+	require.NoError(t, os.MkdirAll(store.basePath, 0o755))
+	require.NoError(t, os.WriteFile(path, []byte("not-json"), 0o644))
+
+	_, err := store.Load(context.Background(), "conv-1")
+	require.Error(t, err)
+}
+
+func TestLocalStoreMultipleSaveLoadCycles(t *testing.T) {
+	store := newLocalStore(t)
+	ctx := context.Background()
+	conversation := Conversation{
+		ID: "conv-1",
+		Messages: []MessageRecord{
+			{
+				ID:         "msg-1",
+				CreatedAt:  time.Date(2024, 10, 12, 8, 0, 0, 0, time.UTC),
+				TokenCount: 2,
+				Message:    message.NewHumanMessage("first"),
+			},
+		},
+	}
+
+	require.NoError(t, store.Save(ctx, conversation))
+	loaded, err := store.Load(ctx, conversation.ID)
+	require.NoError(t, err)
+	require.Equal(t, conversation.Messages, loaded.Messages)
+
+	require.NoError(t, store.Save(ctx, loaded))
+	loadedAgain, err := store.Load(ctx, conversation.ID)
+	require.NoError(t, err)
+	require.Equal(t, loaded.Messages, loadedAgain.Messages)
+}
+
+func newLocalStore(t *testing.T) *LocalStore {
+	t.Helper()
+	store, err := NewLocalStore(t.TempDir())
+	require.NoError(t, err)
+	return store
+}
+
+func writePersistedConversation(t *testing.T, basePath, conversationID string, conversation persistedConversation) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(basePath, 0o755))
+	data, err := json.Marshal(conversation)
+	require.NoError(t, err)
+	path := filepath.Join(basePath, conversationID+".json")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+}
+
+func persistedMessageFixture(t *testing.T) persistedMessage {
+	t.Helper()
+	env, err := message.Encode(message.NewHumanMessage("hello"))
+	require.NoError(t, err)
+	return persistedMessage{
+		ID:         "msg-1",
+		CreatedAt:  time.Date(2024, 10, 12, 8, 0, 0, 0, time.UTC),
+		TokenCount: 1,
+		Envelope:   env,
+	}
+}

--- a/internal/state/remote_test.go
+++ b/internal/state/remote_test.go
@@ -1,0 +1,17 @@
+package state
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRemoteStoreNotImplemented(t *testing.T) {
+	store := NewRemoteStore()
+	_, err := store.Load(context.Background(), "conv-1")
+	require.ErrorIs(t, err, ErrRemoteNotImplemented)
+
+	err = store.Save(context.Background(), Conversation{ID: "conv-1"})
+	require.ErrorIs(t, err, ErrRemoteNotImplemented)
+}

--- a/internal/summarize/summarize_test.go
+++ b/internal/summarize/summarize_test.go
@@ -1,0 +1,123 @@
+package summarize
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agynio/agn-cli/internal/llm"
+	"github.com/agynio/agn-cli/internal/message"
+	"github.com/agynio/agn-cli/internal/state"
+)
+
+func TestNewSummarizerValidation(t *testing.T) {
+	_, err := New(nil, Config{})
+	require.Error(t, err)
+
+	client := mustClient(t)
+	_, err = New(client, Config{KeepTokens: 10, MaxTokens: 5})
+	require.Error(t, err)
+}
+
+func TestNewSummarizerDefaults(t *testing.T) {
+	client := mustClient(t)
+	instance, err := New(client, Config{})
+	require.NoError(t, err)
+	require.Equal(t, DefaultKeepTokens, instance.keepTokens)
+	require.Equal(t, DefaultMaxTokens, instance.maxTokens)
+
+	count, err := instance.CountTokens(message.NewHumanMessage("abcd"))
+	require.NoError(t, err)
+	require.Equal(t, 2, count)
+}
+
+func TestDefaultTokenCounter(t *testing.T) {
+	count, err := DefaultTokenCounter(message.NewHumanMessage("abcdefgh"))
+	require.NoError(t, err)
+	require.Equal(t, 3, count)
+
+	count, err = DefaultTokenCounter(message.NewHumanMessage(""))
+	require.NoError(t, err)
+	require.Equal(t, 1, count)
+}
+
+func TestSummarizeUnderThreshold(t *testing.T) {
+	client := mustClient(t)
+	instance, err := New(client, Config{
+		KeepTokens: 5,
+		MaxTokens:  10,
+		TokenCounter: func(msg message.Message) (int, error) {
+			return 1, nil
+		},
+	})
+	require.NoError(t, err)
+
+	records := []state.MessageRecord{
+		{
+			ID:         "msg-1",
+			CreatedAt:  time.Now().UTC(),
+			TokenCount: 3,
+			Message:    message.NewHumanMessage("hello"),
+		},
+		{
+			ID:         "msg-2",
+			CreatedAt:  time.Now().UTC(),
+			TokenCount: 2,
+			Message:    message.NewAIMessage("world"),
+		},
+	}
+
+	result, err := instance.Summarize(context.Background(), records)
+	require.NoError(t, err)
+	require.Equal(t, records, result)
+}
+
+func TestSummarizeEmptyInput(t *testing.T) {
+	client := mustClient(t)
+	instance, err := New(client, Config{})
+	require.NoError(t, err)
+
+	result, err := instance.Summarize(context.Background(), nil)
+	require.NoError(t, err)
+	require.Empty(t, result)
+}
+
+func TestSummarizeEmptySummaryInput(t *testing.T) {
+	client := mustClient(t)
+	instance, err := New(client, Config{KeepTokens: 1, MaxTokens: 2})
+	require.NoError(t, err)
+
+	records := []state.MessageRecord{
+		{
+			ID:         "msg-1",
+			CreatedAt:  time.Now().UTC().Add(-2 * time.Minute),
+			TokenCount: 2,
+			Message:    message.NewResponseMessage("raw"),
+		},
+		{
+			ID:         "msg-2",
+			CreatedAt:  time.Now().UTC().Add(-1 * time.Minute),
+			TokenCount: 2,
+			Message:    message.NewResponseMessage("raw"),
+		},
+		{
+			ID:         "msg-3",
+			CreatedAt:  time.Now().UTC(),
+			TokenCount: 2,
+			Message:    message.NewHumanMessage("keep"),
+		},
+	}
+
+	result, err := instance.Summarize(context.Background(), records)
+	require.NoError(t, err)
+	require.Equal(t, records, result)
+}
+
+func mustClient(t *testing.T) *llm.Client {
+	t.Helper()
+	client, err := llm.NewClient("https://example.com", "key", "model")
+	require.NoError(t, err)
+	return client
+}

--- a/sdk/client_test.go
+++ b/sdk/client_test.go
@@ -1,0 +1,127 @@
+package agnsdk
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientTurnValidation(t *testing.T) {
+	client := &Client{}
+	_, err := client.Turn(context.Background(), TurnParams{Prompt: " "}, nil)
+	require.Error(t, err)
+}
+
+func TestClientCancelValidation(t *testing.T) {
+	client := &Client{}
+	err := client.Cancel(context.Background(), " ")
+	require.Error(t, err)
+}
+
+func TestClientTurnRequest(t *testing.T) {
+	client, reqReader, respWriter, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	var result TurnResult
+	var err error
+	done := make(chan struct{})
+	go func() {
+		result, err = client.Turn(ctx, TurnParams{Prompt: "hello"}, nil)
+		close(done)
+	}()
+
+	req := readRequest(t, reqReader)
+	require.Equal(t, jsonRPCVersion, req.JSONRPC)
+	require.Equal(t, int64(1), req.ID)
+	require.Equal(t, "agent.turn", req.Method)
+	params, ok := req.Params.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "hello", params["prompt"])
+
+	writeResponse(t, respWriter, req.ID, TurnResult{ConversationID: "conv", Response: "ok"}, nil)
+	<-done
+	require.NoError(t, err)
+	require.Equal(t, TurnResult{ConversationID: "conv", Response: "ok"}, result)
+}
+
+func TestClientCancelRequest(t *testing.T) {
+	client, reqReader, respWriter, cleanup := setupTestClient(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	var err error
+	done := make(chan struct{})
+	go func() {
+		err = client.Cancel(ctx, "req-1")
+		close(done)
+	}()
+
+	req := readRequest(t, reqReader)
+	require.Equal(t, jsonRPCVersion, req.JSONRPC)
+	require.Equal(t, int64(1), req.ID)
+	require.Equal(t, "agent.cancel", req.Method)
+	params, ok := req.Params.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, "req-1", params["request_id"])
+
+	writeResponse(t, respWriter, req.ID, map[string]bool{"cancelled": true}, nil)
+	<-done
+	require.NoError(t, err)
+}
+
+func setupTestClient(t *testing.T) (*Client, *bufio.Reader, io.WriteCloser, func()) {
+	t.Helper()
+	serverToClientR, serverToClientW := io.Pipe()
+	clientToServerR, clientToServerW := io.Pipe()
+	client := &Client{
+		stdin:    clientToServerW,
+		stdout:   serverToClientR,
+		pending:  make(map[string]chan rpcResponse),
+		handlers: make(map[string]func(Event)),
+		done:     make(chan struct{}),
+	}
+	go client.readLoop()
+	reader := bufio.NewReader(clientToServerR)
+	cleanup := func() {
+		_ = serverToClientW.Close()
+		_ = clientToServerW.Close()
+		_ = clientToServerR.Close()
+		_ = serverToClientR.Close()
+		_ = client.Close()
+	}
+	return client, reader, serverToClientW, cleanup
+}
+
+func readRequest(t *testing.T, reader *bufio.Reader) rpcRequest {
+	t.Helper()
+	line, err := reader.ReadString('\n')
+	require.NoError(t, err)
+	line = strings.TrimSpace(line)
+	var req rpcRequest
+	require.NoError(t, json.Unmarshal([]byte(line), &req))
+	return req
+}
+
+func writeResponse(t *testing.T, writer io.Writer, id int64, result any, errObj *rpcError) {
+	t.Helper()
+	resp := rpcResponse{JSONRPC: jsonRPCVersion, ID: json.RawMessage(strconv.FormatInt(id, 10))}
+	if errObj != nil {
+		resp.Error = errObj
+	} else {
+		payload, err := json.Marshal(result)
+		require.NoError(t, err)
+		resp.Result = payload
+	}
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+	data = append(data, '\n')
+	_, err = writer.Write(data)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Summary
- add LLM, loop, summarize, and state unit coverage for mapping and validation paths
- add MCP and server JSON-RPC pipe-based tests for request/response handling
- add SDK client validation and request/response tests

## Testing
- go vet ./...
- go test ./...

Refs: #8