### PR TITLE
Hardcode e2e LLM config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -13,9 +13,6 @@ jobs:
       contents: read
     env:
       GO111MODULE: on
-      AGN_E2E_LLM_ENDPOINT: https://testllm.dev/v1/org/agynio/suite/codex
-      AGN_E2E_LLM_MODEL: simple-hello
-      AGN_E2E_LLM_API_KEY: test-key
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,7 +4,6 @@ package e2e
 
 import (
 	"context"
-	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,11 +18,11 @@ import (
 	"github.com/openai/openai-go/v3/responses"
 )
 
-type e2eConfig struct {
-	endpoint string
-	model    string
-	apiKey   string
-}
+const (
+	testEndpoint = "https://testllm.dev/v1/org/agynio/suite/codex"
+	testModel    = "simple-hello"
+	testAPIKey   = "test-key"
+)
 
 func TestAgentHelloResponse(t *testing.T) {
 	ctx, cancel := newTestContext(t)
@@ -94,8 +93,7 @@ func newTestContext(t *testing.T) (context.Context, context.CancelFunc) {
 
 func newTestClient(t *testing.T) *llm.Client {
 	t.Helper()
-	cfg := loadE2EConfig()
-	client, err := llm.NewClient(cfg.endpoint, cfg.apiKey, cfg.model)
+	client, err := llm.NewClient(testEndpoint, testAPIKey, testModel)
 	require.NoError(t, err)
 	return client
 }
@@ -125,20 +123,4 @@ func newTestAgent(t *testing.T, store state.Store, client *llm.Client, summarize
 	})
 	require.NoError(t, err)
 	return agent
-}
-
-func loadE2EConfig() e2eConfig {
-	return e2eConfig{
-		endpoint: envOrDefault("AGN_E2E_LLM_ENDPOINT", "https://testllm.dev/v1/org/agynio/suite/codex"),
-		model:    envOrDefault("AGN_E2E_LLM_MODEL", "simple-hello"),
-		apiKey:   envOrDefault("AGN_E2E_LLM_API_KEY", "test-key"),
-	}
-}
-
-func envOrDefault(name, fallback string) string {
-	value := strings.TrimSpace(os.Getenv(name))
-	if value == "" {
-		return fallback
-	}
-	return value
 }


### PR DESCRIPTION
## Summary
- replace env-driven e2e test configuration with hardcoded constants
- remove e2e workflow env vars now unused

## Testing
- go vet ./...
- go test ./...
- go test -v -count=1 -tags e2e ./test/e2e/

Refs #10