### PR TITLE
test(e2e): add agn exec flow

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,123 +4,83 @@ package e2e
 
 import (
 	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-
-	"github.com/agynio/agn-cli/internal/llm"
-	"github.com/agynio/agn-cli/internal/loop"
-	"github.com/agynio/agn-cli/internal/message"
-	"github.com/agynio/agn-cli/internal/state"
-	"github.com/agynio/agn-cli/internal/summarize"
-	"github.com/openai/openai-go/v3/responses"
 )
 
 const (
-	testEndpoint = "https://testllm.dev/v1/org/agynio/suite/codex"
-	testModel    = "simple-hello"
-	testAPIKey   = "test-key"
+	testEndpoint     = "https://testllm.dev/v1/org/agynio/suite/agn"
+	testModel        = "simple-hello"
+	testAPIKey       = "test-key"
+	expectedResponse = "Hi! How are you?"
 )
 
-func TestAgentHelloResponse(t *testing.T) {
-	ctx, cancel := newTestContext(t)
+func TestAgnExecHello(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
 
-	client := newTestClient(t)
-	summarizer := newTestSummarizer(t, client)
-	store := newTestStore(t)
-	agent := newTestAgent(t, store, client, summarizer)
+	tempDir := t.TempDir()
+	configPath := filepath.Join(tempDir, "config.yaml")
+	config := fmt.Sprintf(`llm:
+  endpoint: %s
+  auth:
+    api_key: %s
+  model: %s
+`, testEndpoint, testAPIKey, testModel)
+	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
 
-	result, err := agent.Run(ctx, loop.Input{
-		Prompt: message.NewHumanMessage("hello"),
-		Stream: false,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, result.ConversationID)
-	require.Equal(t, "Hi! How are you?", result.Response)
-}
-
-func TestLLMClientDirect(t *testing.T) {
-	ctx, cancel := newTestContext(t)
-	defer cancel()
-
-	client := newTestClient(t)
-	inputs, err := llm.MessagesToInput([]message.Message{message.NewHumanMessage("hello")})
+	repoRoot, err := resolveRepoRoot()
 	require.NoError(t, err)
 
-	response, err := client.CreateResponse(
-		ctx,
-		"",
-		inputs,
-		nil,
-		responses.ResponseNewParamsToolChoiceUnion{},
-		false,
-		nil,
+	binPath := filepath.Join(tempDir, "agn")
+	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./cmd/agn")
+	buildCmd.Dir = repoRoot
+	buildOutput, err := buildCmd.CombinedOutput()
+	require.NoError(t, err, "go build failed: %s", strings.TrimSpace(string(buildOutput)))
+
+	execCmd := exec.CommandContext(ctx, binPath, "exec", "hi")
+	execCmd.Env = append(filteredEnv(os.Environ(), "HOME", "AGN_CONFIG_PATH", "AGN_MCP_COMMAND"),
+		"HOME="+tempDir,
+		"AGN_CONFIG_PATH="+configPath,
+		"AGN_MCP_COMMAND=",
 	)
-	require.NoError(t, err)
-	require.NotNil(t, response)
-	require.NotEmpty(t, response.ID)
-	require.Equal(t, "Hi! How are you?", strings.TrimSpace(response.OutputText()))
+	output, err := execCmd.CombinedOutput()
+	require.NoError(t, err, "agn exec failed: %s", strings.TrimSpace(string(output)))
+
+	require.Equal(t, expectedResponse, strings.TrimSpace(string(output)))
 }
 
-func TestStatePersistence(t *testing.T) {
-	ctx, cancel := newTestContext(t)
-	defer cancel()
-
-	client := newTestClient(t)
-	summarizer := newTestSummarizer(t, client)
-	store := newTestStore(t)
-	agent := newTestAgent(t, store, client, summarizer)
-
-	result, err := agent.Run(ctx, loop.Input{
-		Prompt: message.NewHumanMessage("hello"),
-		Stream: false,
-	})
-	require.NoError(t, err)
-	require.NotEmpty(t, result.ConversationID)
-
-	conversation, err := store.Load(ctx, result.ConversationID)
-	require.NoError(t, err)
-	require.GreaterOrEqual(t, len(conversation.Messages), 2, "expected at least user prompt and assistant response")
+func resolveRepoRoot() (string, error) {
+	workDir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Abs(filepath.Join(workDir, "../.."))
 }
 
-func newTestContext(t *testing.T) (context.Context, context.CancelFunc) {
-	t.Helper()
-	return context.WithTimeout(context.Background(), 30*time.Second)
+func filteredEnv(env []string, keys ...string) []string {
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if shouldSkipEnv(entry, keys) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }
 
-func newTestClient(t *testing.T) *llm.Client {
-	t.Helper()
-	client, err := llm.NewClient(testEndpoint, testAPIKey, testModel)
-	require.NoError(t, err)
-	return client
-}
-
-func newTestSummarizer(t *testing.T, client *llm.Client) *summarize.Summarizer {
-	t.Helper()
-	summarizer, err := summarize.New(client, summarize.Config{})
-	require.NoError(t, err)
-	return summarizer
-}
-
-func newTestStore(t *testing.T) *state.LocalStore {
-	t.Helper()
-	store, err := state.NewLocalStore(t.TempDir())
-	require.NoError(t, err)
-	return store
-}
-
-func newTestAgent(t *testing.T, store state.Store, client *llm.Client, summarizer *summarize.Summarizer) *loop.Agent {
-	t.Helper()
-	agent, err := loop.NewAgent(loop.AgentConfig{
-		Store:        store,
-		LLM:          client,
-		Summarizer:   summarizer,
-		MCP:          nil,
-		SystemPrompt: "",
-	})
-	require.NoError(t, err)
-	return agent
+func shouldSkipEnv(entry string, keys []string) bool {
+	for _, key := range keys {
+		if strings.HasPrefix(entry, key+"=") {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- replace the placeholder e2e test with a binary build + exec flow
- add temp config/env wiring for TestLLM hello response

## Testing
- go test ./...
- go vet ./...
- go test -v -count=1 -tags e2e ./test/e2e/

Closes #15