### PR TITLE
feat(exec): add conversation id

### DIFF
--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -34,6 +34,8 @@ func main() {
 }
 
 func execCommand() *cobra.Command {
+	var conversationID string
+
 	cmd := &cobra.Command{
 		Use:   "exec <prompt>",
 		Short: "Run a single prompt and exit",
@@ -53,15 +55,21 @@ func execCommand() *cobra.Command {
 			}
 			defer cleanup()
 			result, err := agent.Run(cmd.Context(), loop.Input{
-				Prompt: message.NewHumanMessage(prompt),
+				Prompt:         message.NewHumanMessage(prompt),
+				ConversationID: strings.TrimSpace(conversationID),
 			})
 			if err != nil {
 				return err
 			}
 			_, err = fmt.Fprintln(cmd.OutOrStdout(), result.Response)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.ErrOrStderr(), "conversation_id: %s\n", result.ConversationID)
 			return err
 		},
 	}
+	cmd.Flags().StringVar(&conversationID, "conversation-id", "", "Conversation ID to resume")
 	return cmd
 }
 

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -17,9 +18,11 @@ import (
 
 const (
 	testEndpoint     = "https://testllm.dev/v1/org/agynio/suite/agn"
-	testModel        = "simple-hello"
 	testAPIKey       = "test-key"
-	expectedResponse = "Hi! How are you?"
+	helloModel       = "simple-hello"
+	stateModel       = "simple-state"
+	helloResponse    = "Hi! How are you?"
+	followUpResponse = "How can I help you?"
 )
 
 func TestAgnExecHello(t *testing.T) {
@@ -27,42 +30,99 @@ func TestAgnExecHello(t *testing.T) {
 	defer cancel()
 
 	tempDir := t.TempDir()
-	configPath := filepath.Join(tempDir, "config.yaml")
+	configPath := writeConfig(t, tempDir, helloModel)
+	repoRoot := resolveRepoRoot(t)
+
+	binPath := buildBinary(t, ctx, repoRoot, tempDir)
+	stdout, stderr, err := runAgnExec(ctx, binPath, tempDir, configPath, "hi", "")
+	require.NoError(t, err, "agn exec failed: stdout=%q stderr=%q", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+	require.Equal(t, helloResponse, strings.TrimSpace(stdout))
+	_ = parseConversationID(t, stderr)
+}
+
+func TestExecStatePersistence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	homeDir := t.TempDir()
+	configPath := writeConfig(t, homeDir, stateModel)
+	repoRoot := resolveRepoRoot(t)
+
+	binPath := buildBinary(t, ctx, repoRoot, homeDir)
+	stdout, stderr, err := runAgnExec(ctx, binPath, homeDir, configPath, "hi", "")
+	require.NoError(t, err, "agn exec failed: stdout=%q stderr=%q", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+	require.Equal(t, helloResponse, strings.TrimSpace(stdout))
+
+	conversationID := parseConversationID(t, stderr)
+	stdout, stderr, err = runAgnExec(ctx, binPath, homeDir, configPath, "fine", conversationID)
+	require.NoError(t, err, "agn exec failed: stdout=%q stderr=%q", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+	require.Equal(t, followUpResponse, strings.TrimSpace(stdout))
+}
+
+func writeConfig(t *testing.T, dir, model string) string {
+	t.Helper()
+	path := filepath.Join(dir, "config.yaml")
 	config := fmt.Sprintf(`llm:
   endpoint: %s
   auth:
     api_key: %s
   model: %s
-`, testEndpoint, testAPIKey, testModel)
-	require.NoError(t, os.WriteFile(configPath, []byte(config), 0o600))
+`, testEndpoint, testAPIKey, model)
+	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
+	return path
+}
 
-	repoRoot, err := resolveRepoRoot()
+func resolveRepoRoot(t *testing.T) string {
+	t.Helper()
+	workDir, err := os.Getwd()
 	require.NoError(t, err)
+	root, err := filepath.Abs(filepath.Join(workDir, "../.."))
+	require.NoError(t, err)
+	return root
+}
 
-	binPath := filepath.Join(tempDir, "agn")
+func buildBinary(t *testing.T, ctx context.Context, repoRoot, dir string) string {
+	t.Helper()
+	binPath := filepath.Join(dir, "agn")
 	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./cmd/agn")
 	buildCmd.Dir = repoRoot
 	buildOutput, err := buildCmd.CombinedOutput()
 	require.NoError(t, err, "go build failed: %s", strings.TrimSpace(string(buildOutput)))
+	return binPath
+}
 
-	execCmd := exec.CommandContext(ctx, binPath, "exec", "hi")
-	execCmd.Env = append(filteredEnv(os.Environ(), "HOME", "AGN_CONFIG_PATH", "AGN_MCP_COMMAND"),
-		"HOME="+tempDir,
+func runAgnExec(ctx context.Context, binPath, homeDir, configPath, prompt, conversationID string) (string, string, error) {
+	args := []string{"exec", prompt}
+	if strings.TrimSpace(conversationID) != "" {
+		args = append(args, "--conversation-id", conversationID)
+	}
+	cmd := exec.CommandContext(ctx, binPath, args...)
+	cmd.Env = append(filteredEnv(os.Environ(), "HOME", "AGN_CONFIG_PATH", "AGN_MCP_COMMAND"),
+		"HOME="+homeDir,
 		"AGN_CONFIG_PATH="+configPath,
 		"AGN_MCP_COMMAND=",
 	)
-	output, err := execCmd.CombinedOutput()
-	require.NoError(t, err, "agn exec failed: %s", strings.TrimSpace(string(output)))
-
-	require.Equal(t, expectedResponse, strings.TrimSpace(string(output)))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
 }
 
-func resolveRepoRoot() (string, error) {
-	workDir, err := os.Getwd()
-	if err != nil {
-		return "", err
+func parseConversationID(t *testing.T, stderr string) string {
+	t.Helper()
+	lines := strings.Split(stderr, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "conversation_id:") {
+			id := strings.TrimSpace(strings.TrimPrefix(line, "conversation_id:"))
+			require.NotEmpty(t, id, "conversation id is empty")
+			return id
+		}
 	}
-	return filepath.Abs(filepath.Join(workDir, "../.."))
+	require.Fail(t, "conversation id not found", "stderr: %s", stderr)
+	return ""
 }
 
 func filteredEnv(env []string, keys ...string) []string {


### PR DESCRIPTION
## Summary
- add `--conversation-id` support to `agn exec` and emit conversation IDs on stderr
- add e2e exec state persistence coverage for conversation reuse

## Testing
- go test ./...
- go vet ./...
- go test -v -count=1 -tags e2e ./test/e2e/

Closes #17