### PR TITLE
feat: align thread protocol

### DIFF
--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -34,8 +34,8 @@ func main() {
 }
 
 func execCommand() *cobra.Command {
+	var threadID string
 	var conversationID string
-
 	cmd := &cobra.Command{
 		Use:   "exec <prompt>",
 		Short: "Run a single prompt and exit",
@@ -49,27 +49,96 @@ func execCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			agent, cleanup, err := buildAgent(cmd.Context(), cfg)
+			agent, _, cleanup, err := buildAgent(cmd.Context(), cfg)
 			if err != nil {
 				return err
 			}
 			defer cleanup()
 			result, err := agent.Run(cmd.Context(), loop.Input{
-				Prompt:         message.NewHumanMessage(prompt),
-				ConversationID: strings.TrimSpace(conversationID),
+				ThreadID: resolveThreadID(threadID, conversationID),
+				Prompt:   message.NewHumanMessage(prompt),
 			})
 			if err != nil {
 				return err
 			}
-			_, err = fmt.Fprintln(cmd.OutOrStdout(), result.Response)
-			if err != nil {
+			if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "thread_id: %s\n", result.ThreadID); err != nil {
 				return err
 			}
-			_, err = fmt.Fprintf(cmd.ErrOrStderr(), "conversation_id: %s\n", result.ConversationID)
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), result.Response)
 			return err
 		},
 	}
+	cmd.Flags().StringVar(&threadID, "thread-id", "", "Thread ID to resume")
 	cmd.Flags().StringVar(&conversationID, "conversation-id", "", "Conversation ID to resume")
+	cmd.AddCommand(execResumeCommand())
+	return cmd
+}
+
+func execResumeCommand() *cobra.Command {
+	var useLast bool
+	cmd := &cobra.Command{
+		Use:   "resume <thread-id> <prompt>",
+		Short: "Resume a thread with a follow-up prompt",
+		Args: func(cmd *cobra.Command, args []string) error {
+			if useLast {
+				if len(args) != 1 {
+					return errors.New("prompt is required when --last is set")
+				}
+				return nil
+			}
+			if len(args) != 2 {
+				return errors.New("thread ID and prompt are required")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cfg, err := config.LoadDefault()
+			if err != nil {
+				return err
+			}
+			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg)
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+
+			var threadID string
+			var prompt string
+			if useLast {
+				threads, err := store.List(cmd.Context())
+				if err != nil {
+					return err
+				}
+				if len(threads) == 0 {
+					return errors.New("no threads found")
+				}
+				threadID = threads[0].ID
+				prompt = strings.TrimSpace(args[0])
+			} else {
+				threadID = strings.TrimSpace(args[0])
+				prompt = strings.TrimSpace(args[1])
+			}
+			if threadID == "" {
+				return errors.New("thread ID is required")
+			}
+			if prompt == "" {
+				return errors.New("prompt is required")
+			}
+			result, err := agent.Run(cmd.Context(), loop.Input{
+				ThreadID: threadID,
+				Prompt:   message.NewHumanMessage(prompt),
+			})
+			if err != nil {
+				return err
+			}
+			if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "thread_id: %s\n", result.ThreadID); err != nil {
+				return err
+			}
+			_, err = fmt.Fprintln(cmd.OutOrStdout(), result.Response)
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&useLast, "last", false, "Use most recent thread")
 	return cmd
 }
 
@@ -82,38 +151,38 @@ func serveCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			agent, cleanup, err := buildAgent(cmd.Context(), cfg)
+			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg)
 			if err != nil {
 				return err
 			}
 			defer cleanup()
-			srv := server.New(agent)
+			srv := server.New(agent, store)
 			return srv.Serve(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout())
 		},
 	}
 	return cmd
 }
 
-func buildAgent(ctx context.Context, cfg config.Config) (*loop.Agent, func(), error) {
+func buildAgent(ctx context.Context, cfg config.Config) (*loop.Agent, state.Store, func(), error) {
 	apiKey, err := cfg.LLM.Auth.ResolveAPIKey()
 	if err != nil {
-		return nil, func() {}, err
+		return nil, nil, func() {}, err
 	}
 	llmClient, err := llm.NewClient(cfg.LLM.Endpoint, apiKey, cfg.LLM.Model)
 	if err != nil {
-		return nil, func() {}, err
+		return nil, nil, func() {}, err
 	}
 	summarizer, err := summarize.New(llmClient, summarize.Config{})
 	if err != nil {
-		return nil, func() {}, err
+		return nil, nil, func() {}, err
 	}
 	store, err := state.NewDefaultLocalStore()
 	if err != nil {
-		return nil, func() {}, err
+		return nil, nil, func() {}, err
 	}
 	mcpClient, err := newMCPClient(ctx)
 	if err != nil {
-		return nil, func() {}, err
+		return nil, nil, func() {}, err
 	}
 	cleanup := func() {
 		if mcpClient != nil {
@@ -129,9 +198,9 @@ func buildAgent(ctx context.Context, cfg config.Config) (*loop.Agent, func(), er
 	})
 	if err != nil {
 		cleanup()
-		return nil, func() {}, err
+		return nil, nil, func() {}, err
 	}
-	return agent, cleanup, nil
+	return agent, store, cleanup, nil
 }
 
 func newMCPClient(ctx context.Context) (*mcp.Client, error) {
@@ -148,4 +217,12 @@ func newMCPClient(ctx context.Context) (*mcp.Client, error) {
 		return nil, err
 	}
 	return client, nil
+}
+
+func resolveThreadID(threadID, conversationID string) string {
+	threadID = strings.TrimSpace(threadID)
+	if threadID != "" {
+		return threadID
+	}
+	return strings.TrimSpace(conversationID)
 }

--- a/internal/loop/agent.go
+++ b/internal/loop/agent.go
@@ -26,13 +26,18 @@ const (
 type EventType string
 
 const (
-	EventModelDelta EventType = "model_delta"
-	EventToolCall   EventType = "tool_call"
-	EventToolResult EventType = "tool_result"
+	EventModelDelta  EventType = "model_delta"
+	EventTurnStarted EventType = "turn_started"
+	EventTurnDone    EventType = "turn_done"
+	EventItemStarted EventType = "item_started"
+	EventItemDone    EventType = "item_done"
 )
 
 type Event struct {
 	Type       EventType
+	ThreadID   string
+	TurnID     string
+	ItemID     string
 	Delta      string
 	ToolName   string
 	ToolCallID string
@@ -41,7 +46,7 @@ type Event struct {
 type EventSink func(Event)
 
 type Input struct {
-	ConversationID string
+	ThreadID       string
 	Prompt         message.HumanMessage
 	RestrictOutput bool
 	Stream         bool
@@ -49,12 +54,13 @@ type Input struct {
 }
 
 type Result struct {
-	ConversationID string
-	Response       string
+	ThreadID string
+	Response string
 }
 
 type State struct {
-	Conversation     state.Conversation
+	Thread           state.Thread
+	TurnID           string
 	Input            *message.HumanMessage
 	RestrictOutput   bool
 	Stream           bool
@@ -131,9 +137,9 @@ func NewAgent(cfg AgentConfig) (*Agent, error) {
 }
 
 func (a *Agent) Run(ctx context.Context, input Input) (Result, error) {
-	conversationID := strings.TrimSpace(input.ConversationID)
-	if conversationID == "" {
-		conversationID = uuid.NewString()
+	threadID := strings.TrimSpace(input.ThreadID)
+	if threadID == "" {
+		threadID = uuid.NewString()
 	}
 	if strings.TrimSpace(input.Prompt.Text) == "" {
 		return Result{}, errors.New("prompt is required")
@@ -141,8 +147,14 @@ func (a *Agent) Run(ctx context.Context, input Input) (Result, error) {
 	if input.Stream && input.EventSink == nil {
 		return Result{}, errors.New("streaming requires an event sink")
 	}
+	turnID := uuid.NewString()
+	if input.EventSink != nil {
+		input.EventSink(Event{Type: EventTurnStarted, ThreadID: threadID, TurnID: turnID})
+		defer input.EventSink(Event{Type: EventTurnDone, ThreadID: threadID, TurnID: turnID})
+	}
 	state := &State{
-		Conversation:   state.Conversation{ID: conversationID},
+		Thread:         state.Thread{ID: threadID, Messages: []state.MessageRecord{}},
+		TurnID:         turnID,
 		Input:          &input.Prompt,
 		RestrictOutput: input.RestrictOutput,
 		Stream:         input.Stream,
@@ -154,21 +166,21 @@ func (a *Agent) Run(ctx context.Context, input Input) (Result, error) {
 	if strings.TrimSpace(state.LastAssistant) == "" {
 		return Result{}, errors.New("no response generated")
 	}
-	return Result{ConversationID: conversationID, Response: state.LastAssistant}, nil
+	return Result{ThreadID: threadID, Response: state.LastAssistant}, nil
 }
 
 func (a *Agent) load(ctx context.Context, state *State) error {
-	conv, err := a.store.Load(ctx, state.Conversation.ID)
+	thread, err := a.store.Load(ctx, state.Thread.ID)
 	if err != nil {
 		return err
 	}
-	state.Conversation = conv
+	state.Thread = thread
 	if state.Input != nil {
-		record, err := a.recordFromMessage(*state.Input)
+		record, err := a.recordFromMessage("", *state.Input)
 		if err != nil {
 			return err
 		}
-		state.Conversation.Messages = append(state.Conversation.Messages, record)
+		state.Thread.Messages = append(state.Thread.Messages, record)
 	}
 	if a.mcp != nil {
 		tools, err := a.mcp.ListTools(ctx)
@@ -184,11 +196,11 @@ func (a *Agent) load(ctx context.Context, state *State) error {
 }
 
 func (a *Agent) summarize(ctx context.Context, state *State) error {
-	updated, err := a.summarizer.Summarize(ctx, state.Conversation.Messages)
+	updated, err := a.summarizer.Summarize(ctx, state.Thread.Messages)
 	if err != nil {
 		return err
 	}
-	state.Conversation.Messages = updated
+	state.Thread.Messages = updated
 	return nil
 }
 
@@ -207,10 +219,13 @@ func (a *Agent) callModel(ctx context.Context, state *State) error {
 		toolChoice.OfToolChoiceMode = openai.Opt(responses.ToolChoiceOptionsRequired)
 	}
 
+	itemID := uuid.NewString()
 	var onDelta func(string)
-	if state.Stream {
+	if state.EventSink != nil {
+		threadID := state.Thread.ID
+		turnID := state.TurnID
 		onDelta = func(delta string) {
-			state.EventSink(Event{Type: EventModelDelta, Delta: delta})
+			state.EventSink(Event{Type: EventModelDelta, ThreadID: threadID, TurnID: turnID, ItemID: itemID, Delta: delta})
 		}
 	}
 
@@ -227,26 +242,21 @@ func (a *Agent) callModel(ctx context.Context, state *State) error {
 
 	if text != "" {
 		msg := message.NewAIMessage(text)
-		record, err := a.recordFromMessage(msg)
+		record, err := a.recordFromMessage(itemID, msg)
 		if err != nil {
 			return err
 		}
-		state.Conversation.Messages = append(state.Conversation.Messages, record)
+		state.Thread.Messages = append(state.Thread.Messages, record)
 		state.LastAssistant = text
 	}
 	if len(toolCalls) > 0 {
 		msg := message.NewToolCallMessage(toolCalls)
-		record, err := a.recordFromMessage(msg)
+		record, err := a.recordFromMessage("", msg)
 		if err != nil {
 			return err
 		}
-		state.Conversation.Messages = append(state.Conversation.Messages, record)
+		state.Thread.Messages = append(state.Thread.Messages, record)
 		state.PendingToolCalls = toolCalls
-		if state.Stream {
-			for _, call := range toolCalls {
-				state.EventSink(Event{Type: EventToolCall, ToolName: call.Name, ToolCallID: call.ID})
-			}
-		}
 	}
 	state.ForceToolCall = false
 	return nil
@@ -277,6 +287,9 @@ func (a *Agent) callTools(ctx context.Context, state *State) error {
 		return errors.New("mcp client is not configured")
 	}
 	for _, call := range state.PendingToolCalls {
+		if state.EventSink != nil {
+			state.EventSink(Event{Type: EventItemStarted, ThreadID: state.Thread.ID, TurnID: state.TurnID, ItemID: call.ID, ToolName: call.Name})
+		}
 		result, err := a.mcp.CallTool(ctx, mcp.ToolCall{ID: call.ID, Name: call.Name, Arguments: call.Arguments})
 		if err != nil {
 			return err
@@ -287,13 +300,13 @@ func (a *Agent) callTools(ctx context.Context, state *State) error {
 			Output:     result.Content,
 		}
 		msg := message.NewToolCallOutputMessage(output)
-		record, err := a.recordFromMessage(msg)
+		record, err := a.recordFromMessage("", msg)
 		if err != nil {
 			return err
 		}
-		state.Conversation.Messages = append(state.Conversation.Messages, record)
-		if state.Stream {
-			state.EventSink(Event{Type: EventToolResult, ToolName: call.Name, ToolCallID: call.ID})
+		state.Thread.Messages = append(state.Thread.Messages, record)
+		if state.EventSink != nil {
+			state.EventSink(Event{Type: EventItemDone, ThreadID: state.Thread.ID, TurnID: state.TurnID, ItemID: call.ID, ToolName: call.Name})
 		}
 	}
 	state.PendingToolCalls = nil
@@ -304,17 +317,20 @@ func (a *Agent) save(ctx context.Context, state *State) error {
 	if strings.TrimSpace(state.LastAssistant) == "" {
 		return errors.New("no assistant response to save")
 	}
-	state.Conversation.UpdatedAt = time.Now().UTC()
-	return a.store.Save(ctx, state.Conversation)
+	state.Thread.UpdatedAt = time.Now().UTC()
+	return a.store.Save(ctx, state.Thread)
 }
 
-func (a *Agent) recordFromMessage(msg message.Message) (state.MessageRecord, error) {
+func (a *Agent) recordFromMessage(recordID string, msg message.Message) (state.MessageRecord, error) {
 	count, err := a.summarizer.CountTokens(msg)
 	if err != nil {
 		return state.MessageRecord{}, err
 	}
+	if strings.TrimSpace(recordID) == "" {
+		recordID = uuid.NewString()
+	}
 	return state.MessageRecord{
-		ID:         uuid.NewString(),
+		ID:         recordID,
 		CreatedAt:  time.Now().UTC(),
 		TokenCount: count,
 		Message:    msg,
@@ -322,8 +338,8 @@ func (a *Agent) recordFromMessage(msg message.Message) (state.MessageRecord, err
 }
 
 func (a *Agent) buildContextMessages(state *State) ([]message.Message, error) {
-	contextMessages := make([]message.Message, 0, len(state.Conversation.Messages))
-	for _, record := range state.Conversation.Messages {
+	contextMessages := make([]message.Message, 0, len(state.Thread.Messages))
+	for _, record := range state.Thread.Messages {
 		if !message.IsContextMessage(record.Message) {
 			continue
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -9,15 +9,22 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/agynio/agn-cli/internal/loop"
 	"github.com/agynio/agn-cli/internal/message"
+	"github.com/agynio/agn-cli/internal/state"
 )
 
-const jsonRPCVersion = "2.0"
+const (
+	jsonRPCVersion         = "2.0"
+	defaultThreadListLimit = 50
+	maxThreadListLimit     = 200
+)
 
 type Server struct {
 	agent    *loop.Agent
+	store    state.Store
 	writeMu  sync.Mutex
 	inFlight map[string]context.CancelFunc
 	mu       sync.Mutex
@@ -46,31 +53,94 @@ type rpcError struct {
 
 type TurnParams struct {
 	Prompt         string `json:"prompt"`
+	ThreadID       string `json:"thread_id,omitempty"`
 	ConversationID string `json:"conversation_id,omitempty"`
 	RestrictOutput bool   `json:"restrict_output,omitempty"`
 	Stream         bool   `json:"stream,omitempty"`
 }
 
 type TurnResult struct {
-	ConversationID string `json:"conversation_id"`
-	Response       string `json:"response"`
+	ThreadID string `json:"thread_id"`
+	Response string `json:"response"`
 }
 
 type CancelParams struct {
 	RequestID string `json:"request_id"`
 }
 
-type EventNotification struct {
-	RequestID  string `json:"request_id"`
-	Type       string `json:"type"`
-	Delta      string `json:"delta,omitempty"`
-	ToolName   string `json:"tool_name,omitempty"`
-	ToolCallID string `json:"tool_call_id,omitempty"`
+type AgentMessageDeltaNotification struct {
+	RequestID string `json:"request_id"`
+	ThreadID  string `json:"thread_id"`
+	TurnID    string `json:"turn_id"`
+	ItemID    string `json:"item_id"`
+	Delta     string `json:"delta"`
 }
 
-func New(agent *loop.Agent) *Server {
+type ItemLifecycleNotification struct {
+	RequestID string `json:"request_id"`
+	ThreadID  string `json:"thread_id"`
+	TurnID    string `json:"turn_id"`
+	ItemID    string `json:"item_id"`
+	ToolName  string `json:"tool_name"`
+}
+
+type TurnLifecycleNotification struct {
+	RequestID string `json:"request_id"`
+	ThreadID  string `json:"thread_id"`
+	TurnID    string `json:"turn_id"`
+}
+
+type ThreadListParams struct {
+	Limit  int    `json:"limit,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+type ThreadListResult struct {
+	Data       []state.ThreadSummary `json:"data"`
+	NextCursor *string               `json:"next_cursor"`
+}
+
+type ThreadReadParams struct {
+	ThreadID       string `json:"thread_id"`
+	ConversationID string `json:"conversation_id,omitempty"`
+}
+
+type ThreadReadResult struct {
+	ThreadID  string              `json:"thread_id"`
+	UpdatedAt time.Time           `json:"updated_at"`
+	Messages  []ThreadReadMessage `json:"messages"`
+}
+
+type ThreadReadMessage struct {
+	ID         string          `json:"id"`
+	CreatedAt  time.Time       `json:"created_at"`
+	Role       string          `json:"role"`
+	Kind       string          `json:"kind"`
+	Text       string          `json:"text,omitempty"`
+	ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+	ToolOutput json.RawMessage `json:"tool_output,omitempty"`
+}
+
+type ThreadResumeParams struct {
+	ThreadID       string `json:"thread_id"`
+	ConversationID string `json:"conversation_id,omitempty"`
+	Prompt         string `json:"prompt"`
+	RestrictOutput bool   `json:"restrict_output,omitempty"`
+	Stream         bool   `json:"stream,omitempty"`
+}
+
+func resolveThreadID(threadID, conversationID string) string {
+	threadID = strings.TrimSpace(threadID)
+	if threadID != "" {
+		return threadID
+	}
+	return strings.TrimSpace(conversationID)
+}
+
+func New(agent *loop.Agent, store state.Store) *Server {
 	return &Server{
 		agent:    agent,
+		store:    store,
 		inFlight: make(map[string]context.CancelFunc),
 	}
 }
@@ -112,10 +182,16 @@ func (s *Server) Serve(ctx context.Context, reader io.Reader, writer io.Writer) 
 		}
 		id := req.ID
 		switch req.Method {
-		case "agent.turn":
+		case "turn/start", "agent.turn":
 			go s.handleTurn(ctx, req, writer)
-		case "agent.cancel":
+		case "turn/interrupt", "agent.cancel":
 			go s.handleCancel(ctx, req, writer)
+		case "thread/list":
+			go s.handleThreadList(ctx, req, writer)
+		case "thread/read":
+			go s.handleThreadRead(ctx, req, writer)
+		case "thread/resume":
+			go s.handleThreadResume(ctx, req, writer)
 		default:
 			s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: id, Error: &rpcError{Code: -32601, Message: "method not found"}})
 		}
@@ -140,27 +216,8 @@ func (s *Server) handleTurn(ctx context.Context, req request, writer io.Writer) 
 		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "prompt is required"}})
 		return
 	}
-	ctx, cancel := context.WithCancel(ctx)
-	idKey := string(req.ID)
-	s.storeCancel(idKey, cancel)
-	defer s.removeCancel(idKey)
-
-	input := loop.Input{
-		ConversationID: params.ConversationID,
-		Prompt:         message.NewHumanMessage(prompt),
-		RestrictOutput: params.RestrictOutput,
-		Stream:         params.Stream,
-	}
-	if params.Stream {
-		input.EventSink = s.eventSink(writer, idKey)
-	}
-	result, err := s.agent.Run(ctx, input)
-	if err != nil {
-		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}})
-		return
-	}
-
-	s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: TurnResult{ConversationID: result.ConversationID, Response: result.Response}})
+	threadID := resolveThreadID(params.ThreadID, params.ConversationID)
+	s.executeTurn(ctx, req, writer, threadID, prompt, params.RestrictOutput, params.Stream)
 }
 
 func (s *Server) handleCancel(ctx context.Context, req request, writer io.Writer) {
@@ -182,31 +239,227 @@ func (s *Server) handleCancel(ctx context.Context, req request, writer io.Writer
 	s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: map[string]bool{"cancelled": true}})
 }
 
-func (s *Server) eventSink(writer io.Writer, requestID string) loop.EventSink {
-	return func(event loop.Event) {
-		notification := map[string]interface{}{
-			"jsonrpc": jsonRPCVersion,
-			"method":  "agent.event",
-			"params": EventNotification{
-				RequestID:  requestID,
-				Type:       string(event.Type),
-				Delta:      event.Delta,
-				ToolName:   event.ToolName,
-				ToolCallID: event.ToolCallID,
-			},
+func (s *Server) handleThreadList(ctx context.Context, req request, writer io.Writer) {
+	if s.store == nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: "state store is not configured"}})
+		return
+	}
+	var params ThreadListParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "invalid params"}})
+		return
+	}
+	limit := params.Limit
+	if limit <= 0 {
+		limit = defaultThreadListLimit
+	}
+	if limit > maxThreadListLimit {
+		limit = maxThreadListLimit
+	}
+	threads, err := s.store.List(ctx)
+	if err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}})
+		return
+	}
+	start := 0
+	cursor := strings.TrimSpace(params.Cursor)
+	if cursor != "" {
+		found := false
+		for i, summary := range threads {
+			if summary.ID == cursor {
+				start = i + 1
+				found = true
+				break
+			}
 		}
-		payload, err := json.Marshal(notification)
-		if err != nil {
-			s.signalShutdown(fmt.Errorf("marshal event: %w", err))
+		if !found {
+			s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "cursor not found"}})
 			return
 		}
-		payload = append(payload, '\n')
-		s.writeMu.Lock()
-		_, err = writer.Write(payload)
-		s.writeMu.Unlock()
+	}
+	if start > len(threads) {
+		start = len(threads)
+	}
+	end := start + limit
+	if end > len(threads) {
+		end = len(threads)
+	}
+	data := threads[start:end]
+	var nextCursor *string
+	if end < len(threads) && len(data) > 0 {
+		next := data[len(data)-1].ID
+		nextCursor = &next
+	}
+	s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: ThreadListResult{Data: data, NextCursor: nextCursor}})
+}
+
+func (s *Server) handleThreadRead(ctx context.Context, req request, writer io.Writer) {
+	if s.store == nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: "state store is not configured"}})
+		return
+	}
+	var params ThreadReadParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "invalid params"}})
+		return
+	}
+	threadID := resolveThreadID(params.ThreadID, params.ConversationID)
+	if threadID == "" {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "thread_id is required"}})
+		return
+	}
+	thread, err := s.store.Load(ctx, threadID)
+	if err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}})
+		return
+	}
+	messages, err := threadMessagesToWire(thread.Messages)
+	if err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}})
+		return
+	}
+	s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: ThreadReadResult{ThreadID: thread.ID, UpdatedAt: thread.UpdatedAt, Messages: messages}})
+}
+
+func threadMessagesToWire(records []state.MessageRecord) ([]ThreadReadMessage, error) {
+	messages := make([]ThreadReadMessage, 0, len(records))
+	for _, record := range records {
+		env, err := message.Encode(record.Message)
 		if err != nil {
-			s.signalShutdown(fmt.Errorf("write event: %w", err))
+			return nil, err
 		}
+		entry := ThreadReadMessage{
+			ID:        record.ID,
+			CreatedAt: record.CreatedAt,
+			Role:      string(env.Role),
+			Kind:      string(env.Kind),
+			Text:      env.Text,
+		}
+		if entry.Text == "" && env.Raw != "" {
+			entry.Text = env.Raw
+		}
+		if len(env.ToolCalls) > 0 {
+			payload, err := json.Marshal(env.ToolCalls)
+			if err != nil {
+				return nil, err
+			}
+			entry.ToolCalls = payload
+		}
+		if env.ToolOutput != nil {
+			payload, err := json.Marshal(env.ToolOutput)
+			if err != nil {
+				return nil, err
+			}
+			entry.ToolOutput = payload
+		}
+		messages = append(messages, entry)
+	}
+	return messages, nil
+}
+
+func (s *Server) handleThreadResume(ctx context.Context, req request, writer io.Writer) {
+	var params ThreadResumeParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "invalid params"}})
+		return
+	}
+	threadID := resolveThreadID(params.ThreadID, params.ConversationID)
+	if threadID == "" {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "thread_id is required"}})
+		return
+	}
+	prompt := strings.TrimSpace(params.Prompt)
+	if prompt == "" {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32602, Message: "prompt is required"}})
+		return
+	}
+	s.executeTurn(ctx, req, writer, threadID, prompt, params.RestrictOutput, params.Stream)
+}
+
+func (s *Server) executeTurn(ctx context.Context, req request, writer io.Writer, threadID, prompt string, restrictOutput, stream bool) {
+	ctx, cancel := context.WithCancel(ctx)
+	idKey := string(req.ID)
+	s.storeCancel(idKey, cancel)
+	defer s.removeCancel(idKey)
+
+	input := loop.Input{
+		ThreadID:       threadID,
+		Prompt:         message.NewHumanMessage(prompt),
+		RestrictOutput: restrictOutput,
+		Stream:         stream,
+	}
+	if stream {
+		input.EventSink = s.eventSink(writer, idKey)
+	}
+	result, err := s.agent.Run(ctx, input)
+	if err != nil {
+		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}})
+		return
+	}
+
+	s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: TurnResult{ThreadID: result.ThreadID, Response: result.Response}})
+}
+
+func (s *Server) eventSink(writer io.Writer, requestID string) loop.EventSink {
+	return func(event loop.Event) {
+		switch event.Type {
+		case loop.EventModelDelta:
+			s.writeNotification(writer, "item/agentMessage/delta", AgentMessageDeltaNotification{
+				RequestID: requestID,
+				ThreadID:  event.ThreadID,
+				TurnID:    event.TurnID,
+				ItemID:    event.ItemID,
+				Delta:     event.Delta,
+			})
+		case loop.EventItemStarted:
+			s.writeNotification(writer, "item/started", ItemLifecycleNotification{
+				RequestID: requestID,
+				ThreadID:  event.ThreadID,
+				TurnID:    event.TurnID,
+				ItemID:    event.ItemID,
+				ToolName:  event.ToolName,
+			})
+		case loop.EventItemDone:
+			s.writeNotification(writer, "item/completed", ItemLifecycleNotification{
+				RequestID: requestID,
+				ThreadID:  event.ThreadID,
+				TurnID:    event.TurnID,
+				ItemID:    event.ItemID,
+				ToolName:  event.ToolName,
+			})
+		case loop.EventTurnStarted:
+			s.writeNotification(writer, "turn/started", TurnLifecycleNotification{
+				RequestID: requestID,
+				ThreadID:  event.ThreadID,
+				TurnID:    event.TurnID,
+			})
+		case loop.EventTurnDone:
+			s.writeNotification(writer, "turn/completed", TurnLifecycleNotification{
+				RequestID: requestID,
+				ThreadID:  event.ThreadID,
+				TurnID:    event.TurnID,
+			})
+		}
+	}
+}
+
+func (s *Server) writeNotification(writer io.Writer, method string, params interface{}) {
+	notification := map[string]interface{}{
+		"jsonrpc": jsonRPCVersion,
+		"method":  method,
+		"params":  params,
+	}
+	payload, err := json.Marshal(notification)
+	if err != nil {
+		s.signalShutdown(fmt.Errorf("marshal notification: %w", err))
+		return
+	}
+	payload = append(payload, '\n')
+	s.writeMu.Lock()
+	_, err = writer.Write(payload)
+	s.writeMu.Unlock()
+	if err != nil {
+		s.signalShutdown(fmt.Errorf("write notification: %w", err))
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,7 +88,7 @@ func runServerRequest(t *testing.T, input string) response {
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 	ctx, cancel := context.WithCancel(context.Background())
-	server := New(&loop.Agent{})
+	server := New(&loop.Agent{}, nil)
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, inR, outW)

--- a/internal/state/local.go
+++ b/internal/state/local.go
@@ -7,16 +7,21 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/agynio/agn-cli/internal/message"
 )
 
+const previewMaxRunes = 120
+
 type LocalStore struct {
-	basePath string
+	basePath   string
+	legacyPath string
 }
 
-type persistedConversation struct {
+type persistedThread struct {
 	ID        string             `json:"id"`
 	UpdatedAt time.Time          `json:"updated_at"`
 	Messages  []persistedMessage `json:"messages"`
@@ -30,6 +35,14 @@ type persistedMessage struct {
 }
 
 func DefaultLocalPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve home dir: %w", err)
+	}
+	return filepath.Join(home, ".agyn", "agn", "threads"), nil
+}
+
+func legacyLocalPath() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", fmt.Errorf("resolve home dir: %w", err)
@@ -49,67 +62,52 @@ func NewDefaultLocalStore() (*LocalStore, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewLocalStore(path)
+	legacyPath, err := legacyLocalPath()
+	if err != nil {
+		return nil, err
+	}
+	store, err := NewLocalStore(path)
+	if err != nil {
+		return nil, err
+	}
+	store.legacyPath = legacyPath
+	return store, nil
 }
 
-func (s *LocalStore) Load(ctx context.Context, conversationID string) (Conversation, error) {
-	if conversationID == "" {
-		return Conversation{}, errors.New("conversation ID is required")
+func (s *LocalStore) Load(ctx context.Context, threadID string) (Thread, error) {
+	if threadID == "" {
+		return Thread{}, errors.New("thread ID is required")
 	}
 	select {
 	case <-ctx.Done():
-		return Conversation{}, ctx.Err()
+		return Thread{}, ctx.Err()
 	default:
 	}
 
-	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", conversationID))
-	data, err := os.ReadFile(path)
+	data, err := readThreadFile(s.basePath, threadID)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return Conversation{ID: conversationID, Messages: []MessageRecord{}}, nil
-		}
-		return Conversation{}, fmt.Errorf("read conversation: %w", err)
+		return Thread{}, err
 	}
-
-	var persisted persistedConversation
-	if err := json.Unmarshal(data, &persisted); err != nil {
-		return Conversation{}, fmt.Errorf("parse conversation: %w", err)
-	}
-
-	if persisted.ID == "" {
-		return Conversation{}, errors.New("conversation ID missing in persisted state")
-	}
-	if persisted.ID != conversationID {
-		return Conversation{}, fmt.Errorf("conversation ID mismatch: %s", persisted.ID)
-	}
-
-	messages := make([]MessageRecord, 0, len(persisted.Messages))
-	for _, item := range persisted.Messages {
-		msg, err := message.Decode(item.Envelope)
+	if data == nil && s.legacyPath != "" {
+		data, err = readThreadFile(s.legacyPath, threadID)
 		if err != nil {
-			return Conversation{}, fmt.Errorf("decode message: %w", err)
+			return Thread{}, err
 		}
-		if item.TokenCount <= 0 {
-			return Conversation{}, errors.New("message token count missing")
-		}
-		messages = append(messages, MessageRecord{
-			ID:         item.ID,
-			CreatedAt:  item.CreatedAt,
-			TokenCount: item.TokenCount,
-			Message:    msg,
-		})
+	}
+	if data == nil {
+		return Thread{ID: threadID, Messages: []MessageRecord{}}, nil
 	}
 
-	return Conversation{
-		ID:        persisted.ID,
-		Messages:  messages,
-		UpdatedAt: persisted.UpdatedAt,
-	}, nil
+	thread, err := decodeThread(data, threadID)
+	if err != nil {
+		return Thread{}, err
+	}
+	return thread, nil
 }
 
-func (s *LocalStore) Save(ctx context.Context, conversation Conversation) error {
-	if conversation.ID == "" {
-		return errors.New("conversation ID is required")
+func (s *LocalStore) Save(ctx context.Context, thread Thread) error {
+	if thread.ID == "" {
+		return errors.New("thread ID is required")
 	}
 	select {
 	case <-ctx.Done():
@@ -118,16 +116,16 @@ func (s *LocalStore) Save(ctx context.Context, conversation Conversation) error 
 	}
 
 	if err := os.MkdirAll(s.basePath, 0o755); err != nil {
-		return fmt.Errorf("create state directory: %w", err)
+		return fmt.Errorf("create threads directory: %w", err)
 	}
 
-	persisted := persistedConversation{
-		ID:        conversation.ID,
+	persisted := persistedThread{
+		ID:        thread.ID,
 		UpdatedAt: time.Now().UTC(),
-		Messages:  make([]persistedMessage, 0, len(conversation.Messages)),
+		Messages:  make([]persistedMessage, 0, len(thread.Messages)),
 	}
 
-	for _, record := range conversation.Messages {
+	for _, record := range thread.Messages {
 		env, err := message.Encode(record.Message)
 		if err != nil {
 			return fmt.Errorf("encode message: %w", err)
@@ -142,11 +140,11 @@ func (s *LocalStore) Save(ctx context.Context, conversation Conversation) error 
 
 	data, err := json.MarshalIndent(persisted, "", "  ")
 	if err != nil {
-		return fmt.Errorf("marshal conversation: %w", err)
+		return fmt.Errorf("marshal thread: %w", err)
 	}
 
-	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", conversation.ID))
-	tmp, err := os.CreateTemp(s.basePath, fmt.Sprintf("%s.*.json", conversation.ID))
+	path := filepath.Join(s.basePath, fmt.Sprintf("%s.json", thread.ID))
+	tmp, err := os.CreateTemp(s.basePath, fmt.Sprintf("%s.*.json", thread.ID))
 	if err != nil {
 		return fmt.Errorf("create temp file: %w", err)
 	}
@@ -162,8 +160,172 @@ func (s *LocalStore) Save(ctx context.Context, conversation Conversation) error 
 	}
 	if err := os.Rename(tmp.Name(), path); err != nil {
 		_ = os.Remove(tmp.Name())
-		return fmt.Errorf("commit state file: %w", err)
+		return fmt.Errorf("commit thread file: %w", err)
 	}
 
 	return nil
+}
+
+func (s *LocalStore) List(ctx context.Context) ([]ThreadSummary, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	canonical, err := listThreads(ctx, s.basePath)
+	if err != nil {
+		return nil, err
+	}
+	combined := make(map[string]ThreadSummary, len(canonical))
+	for _, summary := range canonical {
+		combined[summary.ID] = summary
+	}
+	if s.legacyPath != "" {
+		legacy, err := listThreads(ctx, s.legacyPath)
+		if err != nil {
+			return nil, err
+		}
+		for _, summary := range legacy {
+			if _, ok := combined[summary.ID]; ok {
+				continue
+			}
+			combined[summary.ID] = summary
+		}
+	}
+
+	result := make([]ThreadSummary, 0, len(combined))
+	for _, summary := range combined {
+		result = append(result, summary)
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].UpdatedAt.Equal(result[j].UpdatedAt) {
+			return result[i].ID < result[j].ID
+		}
+		return result[i].UpdatedAt.After(result[j].UpdatedAt)
+	})
+	return result, nil
+}
+
+func readThreadFile(basePath, threadID string) ([]byte, error) {
+	path := filepath.Join(basePath, fmt.Sprintf("%s.json", threadID))
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read thread: %w", err)
+	}
+	return data, nil
+}
+
+func decodeThread(data []byte, threadID string) (Thread, error) {
+	var persisted persistedThread
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return Thread{}, fmt.Errorf("parse thread: %w", err)
+	}
+
+	if persisted.ID == "" {
+		persisted.ID = threadID
+	}
+	if persisted.ID != threadID {
+		return Thread{}, fmt.Errorf("thread ID mismatch: %s", persisted.ID)
+	}
+
+	messages := make([]MessageRecord, 0, len(persisted.Messages))
+	for _, item := range persisted.Messages {
+		msg, err := message.Decode(item.Envelope)
+		if err != nil {
+			return Thread{}, fmt.Errorf("decode message: %w", err)
+		}
+		if item.TokenCount <= 0 {
+			return Thread{}, errors.New("message token count missing")
+		}
+		messages = append(messages, MessageRecord{
+			ID:         item.ID,
+			CreatedAt:  item.CreatedAt,
+			TokenCount: item.TokenCount,
+			Message:    msg,
+		})
+	}
+
+	return Thread{
+		ID:        persisted.ID,
+		Messages:  messages,
+		UpdatedAt: persisted.UpdatedAt,
+	}, nil
+}
+
+func listThreads(ctx context.Context, basePath string) ([]ThreadSummary, error) {
+	entries, err := os.ReadDir(basePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read threads directory: %w", err)
+	}
+	result := make([]ThreadSummary, 0, len(entries))
+	for _, entry := range entries {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+		if entry.IsDir() {
+			continue
+		}
+		if filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		path := filepath.Join(basePath, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read thread: %w", err)
+		}
+		var persisted persistedThread
+		if err := json.Unmarshal(data, &persisted); err != nil {
+			return nil, fmt.Errorf("parse thread: %w", err)
+		}
+		id := strings.TrimSuffix(entry.Name(), filepath.Ext(entry.Name()))
+		if persisted.ID == "" {
+			persisted.ID = id
+		}
+		if persisted.ID != id {
+			return nil, fmt.Errorf("thread ID mismatch: %s", persisted.ID)
+		}
+		summary, err := summarizeThread(persisted)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, summary)
+	}
+	return result, nil
+}
+
+func summarizeThread(persisted persistedThread) (ThreadSummary, error) {
+	preview := ""
+	for _, item := range persisted.Messages {
+		msg, err := message.Decode(item.Envelope)
+		if err != nil {
+			return ThreadSummary{}, fmt.Errorf("decode message: %w", err)
+		}
+		human, ok := msg.(message.HumanMessage)
+		if ok {
+			preview = strings.TrimSpace(human.Text)
+			break
+		}
+	}
+	preview = truncatePreview(preview, previewMaxRunes)
+	return ThreadSummary{ID: persisted.ID, Preview: preview, UpdatedAt: persisted.UpdatedAt}, nil
+}
+
+func truncatePreview(text string, limit int) string {
+	if limit <= 0 {
+		return ""
+	}
+	runes := []rune(text)
+	if len(runes) <= limit {
+		return text
+	}
+	return string(runes[:limit])
 }

--- a/internal/state/local_test.go
+++ b/internal/state/local_test.go
@@ -23,7 +23,7 @@ func TestLocalStoreSaveLoadRoundTrip(t *testing.T) {
 	store := newLocalStore(t)
 	ctx := context.Background()
 	createdAt := time.Date(2024, 10, 12, 8, 0, 0, 0, time.UTC)
-	conversation := Conversation{
+	thread := Thread{
 		ID: "conv-1",
 		Messages: []MessageRecord{
 			{
@@ -41,12 +41,12 @@ func TestLocalStoreSaveLoadRoundTrip(t *testing.T) {
 		},
 	}
 	before := time.Now().UTC()
-	require.NoError(t, store.Save(ctx, conversation))
+	require.NoError(t, store.Save(ctx, thread))
 
-	loaded, err := store.Load(ctx, conversation.ID)
+	loaded, err := store.Load(ctx, thread.ID)
 	require.NoError(t, err)
-	require.Equal(t, conversation.ID, loaded.ID)
-	require.Equal(t, conversation.Messages, loaded.Messages)
+	require.Equal(t, thread.ID, loaded.ID)
+	require.Equal(t, thread.Messages, loaded.Messages)
 	require.False(t, loaded.UpdatedAt.IsZero())
 	require.True(t, loaded.UpdatedAt.Equal(before) || loaded.UpdatedAt.After(before))
 }
@@ -54,10 +54,10 @@ func TestLocalStoreSaveLoadRoundTrip(t *testing.T) {
 func TestLocalStoreLoadMissing(t *testing.T) {
 	store := newLocalStore(t)
 	ctx := context.Background()
-	conv, err := store.Load(ctx, "missing")
+	thread, err := store.Load(ctx, "missing")
 	require.NoError(t, err)
-	require.Equal(t, "missing", conv.ID)
-	require.Empty(t, conv.Messages)
+	require.Equal(t, "missing", thread.ID)
+	require.Empty(t, thread.Messages)
 }
 
 func TestLocalStoreLoadSaveEmptyID(t *testing.T) {
@@ -65,14 +65,14 @@ func TestLocalStoreLoadSaveEmptyID(t *testing.T) {
 	ctx := context.Background()
 	_, err := store.Load(ctx, "")
 	require.Error(t, err)
-	returnErr := store.Save(ctx, Conversation{})
+	returnErr := store.Save(ctx, Thread{})
 	require.Error(t, returnErr)
 }
 
 func TestLocalStoreLoadMismatchedID(t *testing.T) {
 	store := newLocalStore(t)
 	ctx := context.Background()
-	writePersistedConversation(t, store.basePath, "expected", persistedConversation{
+	writePersistedThread(t, store.basePath, "expected", persistedThread{
 		ID:        "other",
 		UpdatedAt: time.Now().UTC(),
 		Messages:  []persistedMessage{persistedMessageFixture(t)},
@@ -87,7 +87,7 @@ func TestLocalStoreLoadZeroTokenCount(t *testing.T) {
 	ctx := context.Background()
 	msg := persistedMessageFixture(t)
 	msg.TokenCount = 0
-	writePersistedConversation(t, store.basePath, "conv-1", persistedConversation{
+	writePersistedThread(t, store.basePath, "conv-1", persistedThread{
 		ID:        "conv-1",
 		UpdatedAt: time.Now().UTC(),
 		Messages:  []persistedMessage{msg},
@@ -110,7 +110,7 @@ func TestLocalStoreLoadCorruptJSON(t *testing.T) {
 func TestLocalStoreMultipleSaveLoadCycles(t *testing.T) {
 	store := newLocalStore(t)
 	ctx := context.Background()
-	conversation := Conversation{
+	thread := Thread{
 		ID: "conv-1",
 		Messages: []MessageRecord{
 			{
@@ -122,13 +122,13 @@ func TestLocalStoreMultipleSaveLoadCycles(t *testing.T) {
 		},
 	}
 
-	require.NoError(t, store.Save(ctx, conversation))
-	loaded, err := store.Load(ctx, conversation.ID)
+	require.NoError(t, store.Save(ctx, thread))
+	loaded, err := store.Load(ctx, thread.ID)
 	require.NoError(t, err)
-	require.Equal(t, conversation.Messages, loaded.Messages)
+	require.Equal(t, thread.Messages, loaded.Messages)
 
 	require.NoError(t, store.Save(ctx, loaded))
-	loadedAgain, err := store.Load(ctx, conversation.ID)
+	loadedAgain, err := store.Load(ctx, thread.ID)
 	require.NoError(t, err)
 	require.Equal(t, loaded.Messages, loadedAgain.Messages)
 }
@@ -140,12 +140,12 @@ func newLocalStore(t *testing.T) *LocalStore {
 	return store
 }
 
-func writePersistedConversation(t *testing.T, basePath, conversationID string, conversation persistedConversation) {
+func writePersistedThread(t *testing.T, basePath, threadID string, thread persistedThread) {
 	t.Helper()
 	require.NoError(t, os.MkdirAll(basePath, 0o755))
-	data, err := json.Marshal(conversation)
+	data, err := json.Marshal(thread)
 	require.NoError(t, err)
-	path := filepath.Join(basePath, conversationID+".json")
+	path := filepath.Join(basePath, threadID+".json")
 	require.NoError(t, os.WriteFile(path, data, 0o644))
 }
 

--- a/internal/state/remote.go
+++ b/internal/state/remote.go
@@ -13,10 +13,14 @@ func NewRemoteStore() *RemoteStore {
 	return &RemoteStore{}
 }
 
-func (s *RemoteStore) Load(ctx context.Context, conversationID string) (Conversation, error) {
-	return Conversation{}, ErrRemoteNotImplemented
+func (s *RemoteStore) Load(ctx context.Context, threadID string) (Thread, error) {
+	return Thread{}, ErrRemoteNotImplemented
 }
 
-func (s *RemoteStore) Save(ctx context.Context, conversation Conversation) error {
+func (s *RemoteStore) Save(ctx context.Context, thread Thread) error {
 	return ErrRemoteNotImplemented
+}
+
+func (s *RemoteStore) List(ctx context.Context) ([]ThreadSummary, error) {
+	return nil, ErrRemoteNotImplemented
 }

--- a/internal/state/remote_test.go
+++ b/internal/state/remote_test.go
@@ -12,6 +12,6 @@ func TestRemoteStoreNotImplemented(t *testing.T) {
 	_, err := store.Load(context.Background(), "conv-1")
 	require.ErrorIs(t, err, ErrRemoteNotImplemented)
 
-	err = store.Save(context.Background(), Conversation{ID: "conv-1"})
+	err = store.Save(context.Background(), Thread{ID: "conv-1"})
 	require.ErrorIs(t, err, ErrRemoteNotImplemented)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,13 +14,20 @@ type MessageRecord struct {
 	Message    message.Message
 }
 
-type Conversation struct {
+type Thread struct {
 	ID        string
 	Messages  []MessageRecord
 	UpdatedAt time.Time
 }
 
+type ThreadSummary struct {
+	ID        string    `json:"thread_id"`
+	Preview   string    `json:"preview"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
 type Store interface {
-	Load(ctx context.Context, conversationID string) (Conversation, error)
-	Save(ctx context.Context, conversation Conversation) error
+	Load(ctx context.Context, threadID string) (Thread, error)
+	Save(ctx context.Context, thread Thread) error
+	List(ctx context.Context) ([]ThreadSummary, error)
 }

--- a/internal/summarize/summarize.go
+++ b/internal/summarize/summarize.go
@@ -101,7 +101,7 @@ func (s *Summarizer) Summarize(ctx context.Context, messages []state.MessageReco
 		return messages, nil
 	}
 
-	instructions := "Summarize the conversation history. Keep decisions, tool usage, and requirements. Be concise."
+	instructions := "Summarize the thread history. Keep decisions, tool usage, and requirements. Be concise."
 	user := message.NewHumanMessage(input)
 	inputs, err := llm.MessagesToInput([]message.Message{user})
 	if err != nil {

--- a/sdk/client.go
+++ b/sdk/client.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 )
 
 const jsonRPCVersion = "2.0"
@@ -37,14 +38,50 @@ type Client struct {
 
 type TurnParams struct {
 	Prompt         string `json:"prompt"`
-	ConversationID string `json:"conversation_id,omitempty"`
+	ThreadID       string `json:"thread_id,omitempty"`
 	RestrictOutput bool   `json:"restrict_output,omitempty"`
 	Stream         bool   `json:"stream,omitempty"`
 }
 
 type TurnResult struct {
-	ConversationID string `json:"conversation_id"`
-	Response       string `json:"response"`
+	ThreadID string `json:"thread_id"`
+	Response string `json:"response"`
+}
+
+type ThreadSummary struct {
+	ID        string    `json:"thread_id"`
+	Preview   string    `json:"preview"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+type ThreadReadResult struct {
+	ThreadID  string              `json:"thread_id"`
+	UpdatedAt time.Time           `json:"updated_at"`
+	Messages  []ThreadReadMessage `json:"messages"`
+}
+
+type ThreadReadMessage struct {
+	ID         string          `json:"id"`
+	CreatedAt  time.Time       `json:"created_at"`
+	Role       string          `json:"role"`
+	Kind       string          `json:"kind"`
+	Text       string          `json:"text,omitempty"`
+	ToolCalls  json.RawMessage `json:"tool_calls,omitempty"`
+	ToolOutput json.RawMessage `json:"tool_output,omitempty"`
+}
+
+type ThreadListParams struct {
+	Limit  int    `json:"limit,omitempty"`
+	Cursor string `json:"cursor,omitempty"`
+}
+
+type ThreadListResult struct {
+	Data       []ThreadSummary `json:"data"`
+	NextCursor *string         `json:"next_cursor"`
+}
+
+type ThreadReadParams struct {
+	ThreadID string `json:"thread_id"`
 }
 
 type CancelParams struct {
@@ -52,11 +89,37 @@ type CancelParams struct {
 }
 
 type Event struct {
-	RequestID  string `json:"request_id"`
-	Type       string `json:"type"`
+	Method     string `json:"method,omitempty"`
+	RequestID  string `json:"request_id,omitempty"`
+	Type       string `json:"type,omitempty"`
+	ThreadID   string `json:"thread_id,omitempty"`
+	TurnID     string `json:"turn_id,omitempty"`
+	ItemID     string `json:"item_id,omitempty"`
 	Delta      string `json:"delta,omitempty"`
 	ToolName   string `json:"tool_name,omitempty"`
 	ToolCallID string `json:"tool_call_id,omitempty"`
+}
+
+type agentMessageDeltaNotification struct {
+	RequestID string `json:"request_id"`
+	ThreadID  string `json:"thread_id"`
+	TurnID    string `json:"turn_id"`
+	ItemID    string `json:"item_id"`
+	Delta     string `json:"delta"`
+}
+
+type itemLifecycleNotification struct {
+	RequestID string `json:"request_id"`
+	ThreadID  string `json:"thread_id"`
+	TurnID    string `json:"turn_id"`
+	ItemID    string `json:"item_id"`
+	ToolName  string `json:"tool_name"`
+}
+
+type turnLifecycleNotification struct {
+	RequestID string `json:"request_id"`
+	ThreadID  string `json:"thread_id"`
+	TurnID    string `json:"turn_id"`
 }
 
 type rpcRequest struct {
@@ -120,6 +183,18 @@ func Start(ctx context.Context, opts Options) (*Client, error) {
 }
 
 func (c *Client) Turn(ctx context.Context, params TurnParams, onEvent func(Event)) (TurnResult, error) {
+	return c.runTurn(ctx, "turn/start", params, onEvent)
+}
+
+func (c *Client) Resume(ctx context.Context, threadID string, params TurnParams, onEvent func(Event)) (TurnResult, error) {
+	if strings.TrimSpace(threadID) == "" {
+		return TurnResult{}, errors.New("thread ID is required")
+	}
+	params.ThreadID = threadID
+	return c.runTurn(ctx, "thread/resume", params, onEvent)
+}
+
+func (c *Client) runTurn(ctx context.Context, method string, params TurnParams, onEvent func(Event)) (TurnResult, error) {
 	if strings.TrimSpace(params.Prompt) == "" {
 		return TurnResult{}, errors.New("prompt is required")
 	}
@@ -135,7 +210,7 @@ func (c *Client) Turn(ctx context.Context, params TurnParams, onEvent func(Event
 	}
 	c.mu.Unlock()
 
-	if err := c.sendRequest(rpcRequest{JSONRPC: jsonRPCVersion, ID: requestID, Method: "agent.turn", Params: params}); err != nil {
+	if err := c.sendRequest(rpcRequest{JSONRPC: jsonRPCVersion, ID: requestID, Method: method, Params: params}); err != nil {
 		return TurnResult{}, err
 	}
 
@@ -149,6 +224,69 @@ func (c *Client) Turn(ctx context.Context, params TurnParams, onEvent func(Event
 		var result TurnResult
 		if err := json.Unmarshal(resp.Result, &result); err != nil {
 			return TurnResult{}, fmt.Errorf("parse result: %w", err)
+		}
+		return result, nil
+	}
+}
+
+func (c *Client) ThreadList(ctx context.Context, limit int) (ThreadListResult, error) {
+	requestID := atomic.AddInt64(&c.nextID, 1)
+	idKey := strconv.FormatInt(requestID, 10)
+	respCh := make(chan rpcResponse, 1)
+	defer close(respCh)
+
+	c.mu.Lock()
+	c.pending[idKey] = respCh
+	c.mu.Unlock()
+
+	params := ThreadListParams{Limit: limit}
+	if err := c.sendRequest(rpcRequest{JSONRPC: jsonRPCVersion, ID: requestID, Method: "thread/list", Params: params}); err != nil {
+		return ThreadListResult{}, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ThreadListResult{}, ctx.Err()
+	case resp := <-respCh:
+		if resp.Error != nil {
+			return ThreadListResult{}, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+		}
+		var result ThreadListResult
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			return ThreadListResult{}, fmt.Errorf("parse result: %w", err)
+		}
+		return result, nil
+	}
+}
+
+func (c *Client) ThreadRead(ctx context.Context, threadID string) (ThreadReadResult, error) {
+	if strings.TrimSpace(threadID) == "" {
+		return ThreadReadResult{}, errors.New("thread ID is required")
+	}
+	requestID := atomic.AddInt64(&c.nextID, 1)
+	idKey := strconv.FormatInt(requestID, 10)
+	respCh := make(chan rpcResponse, 1)
+	defer close(respCh)
+
+	c.mu.Lock()
+	c.pending[idKey] = respCh
+	c.mu.Unlock()
+
+	params := ThreadReadParams{ThreadID: threadID}
+	if err := c.sendRequest(rpcRequest{JSONRPC: jsonRPCVersion, ID: requestID, Method: "thread/read", Params: params}); err != nil {
+		return ThreadReadResult{}, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return ThreadReadResult{}, ctx.Err()
+	case resp := <-respCh:
+		if resp.Error != nil {
+			return ThreadReadResult{}, fmt.Errorf("rpc error %d: %s", resp.Error.Code, resp.Error.Message)
+		}
+		var result ThreadReadResult
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			return ThreadReadResult{}, fmt.Errorf("parse result: %w", err)
 		}
 		return result, nil
 	}
@@ -168,7 +306,7 @@ func (c *Client) Cancel(ctx context.Context, requestID string) error {
 	c.pending[idKey] = respCh
 	c.mu.Unlock()
 
-	if err := c.sendRequest(rpcRequest{JSONRPC: jsonRPCVersion, ID: rpcID, Method: "agent.cancel", Params: params}); err != nil {
+	if err := c.sendRequest(rpcRequest{JSONRPC: jsonRPCVersion, ID: rpcID, Method: "turn/interrupt", Params: params}); err != nil {
 		return err
 	}
 
@@ -248,20 +386,74 @@ func (c *Client) readLoop() {
 }
 
 func (c *Client) handleNotification(resp rpcResponse) {
-	if resp.Method != "agent.event" {
-		return
+	switch resp.Method {
+	case "agent.event":
+		var event Event
+		if err := json.Unmarshal(resp.Params, &event); err != nil {
+			return
+		}
+		event.Method = resp.Method
+		if strings.TrimSpace(event.RequestID) == "" {
+			return
+		}
+		c.dispatchEvent(event)
+	case "item/agentMessage/delta":
+		var payload agentMessageDeltaNotification
+		if err := json.Unmarshal(resp.Params, &payload); err != nil {
+			return
+		}
+		c.dispatchEvent(Event{
+			Method:    resp.Method,
+			RequestID: payload.RequestID,
+			ThreadID:  payload.ThreadID,
+			TurnID:    payload.TurnID,
+			ItemID:    payload.ItemID,
+			Delta:     payload.Delta,
+		})
+	case "item/started", "item/completed":
+		var payload itemLifecycleNotification
+		if err := json.Unmarshal(resp.Params, &payload); err != nil {
+			return
+		}
+		c.dispatchEvent(Event{
+			Method:    resp.Method,
+			RequestID: payload.RequestID,
+			ThreadID:  payload.ThreadID,
+			TurnID:    payload.TurnID,
+			ItemID:    payload.ItemID,
+			ToolName:  payload.ToolName,
+		})
+	case "turn/started", "turn/completed":
+		var payload turnLifecycleNotification
+		if err := json.Unmarshal(resp.Params, &payload); err != nil {
+			return
+		}
+		c.dispatchEvent(Event{
+			Method:    resp.Method,
+			RequestID: payload.RequestID,
+			ThreadID:  payload.ThreadID,
+			TurnID:    payload.TurnID,
+		})
 	}
-	var event Event
-	if err := json.Unmarshal(resp.Params, &event); err != nil {
-		return
-	}
-	if strings.TrimSpace(event.RequestID) == "" {
-		return
-	}
+}
+
+func (c *Client) dispatchEvent(event Event) {
+	requestID := strings.TrimSpace(event.RequestID)
 	c.mu.Lock()
-	handler := c.handlers[event.RequestID]
+	if requestID != "" {
+		handler := c.handlers[requestID]
+		c.mu.Unlock()
+		if handler != nil {
+			handler(event)
+		}
+		return
+	}
+	handlers := make([]func(Event), 0, len(c.handlers))
+	for _, handler := range c.handlers {
+		handlers = append(handlers, handler)
+	}
 	c.mu.Unlock()
-	if handler != nil {
+	for _, handler := range handlers {
 		handler(event)
 	}
 }

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,143 +4,257 @@ package e2e
 
 import (
 	"bytes"
-	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
-	"time"
-
-	"github.com/stretchr/testify/require"
 )
 
-const (
-	testEndpoint     = "https://testllm.dev/v1/org/agynio/suite/agn"
-	testAPIKey       = "test-key"
-	helloModel       = "simple-hello"
-	stateModel       = "simple-state"
-	helloResponse    = "Hi! How are you?"
-	followUpResponse = "How can I help you?"
+type testEnv struct {
+	home string
+	env  []string
+}
+
+var (
+	buildOnce sync.Once
+	buildErr  error
+	agnBinary string
 )
 
 func TestAgnExecHello(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
+	server := newStubServer(t)
+	defer server.Close()
 
-	tempDir := t.TempDir()
-	configPath := writeConfig(t, tempDir, helloModel)
-	repoRoot := resolveRepoRoot(t)
+	env := newTestEnv(t, server.URL)
+	binary := buildAgnBinary(t)
 
-	binPath := buildBinary(t, ctx, repoRoot, tempDir)
-	stdout, stderr, err := runAgnExec(ctx, binPath, tempDir, configPath, "hi", "")
-	require.NoError(t, err, "agn exec failed: stdout=%q stderr=%q", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
-	require.Equal(t, helloResponse, strings.TrimSpace(stdout))
-	_ = parseConversationID(t, stderr)
+	stdout, stderr := runAgn(t, binary, env.env, "exec", "hi")
+	if strings.TrimSpace(stdout) != "echo: hi" {
+		t.Fatalf("expected hello response, got %q", stdout)
+	}
+	threadID := parseThreadID(t, stderr)
+	if threadID == "" {
+		t.Fatalf("expected thread_id in stderr, got %q", stderr)
+	}
 }
 
 func TestExecStatePersistence(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
-	defer cancel()
+	server := newStubServer(t)
+	defer server.Close()
 
-	homeDir := t.TempDir()
-	configPath := writeConfig(t, homeDir, stateModel)
-	repoRoot := resolveRepoRoot(t)
+	env := newTestEnv(t, server.URL)
+	binary := buildAgnBinary(t)
+	threadID := "thread-test"
 
-	binPath := buildBinary(t, ctx, repoRoot, homeDir)
-	stdout, stderr, err := runAgnExec(ctx, binPath, homeDir, configPath, "hi", "")
-	require.NoError(t, err, "agn exec failed: stdout=%q stderr=%q", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
-	require.Equal(t, helloResponse, strings.TrimSpace(stdout))
-
-	conversationID := parseConversationID(t, stderr)
-	stdout, stderr, err = runAgnExec(ctx, binPath, homeDir, configPath, "fine", conversationID)
-	require.NoError(t, err, "agn exec failed: stdout=%q stderr=%q", strings.TrimSpace(stdout), strings.TrimSpace(stderr))
-	require.Equal(t, followUpResponse, strings.TrimSpace(stdout))
-}
-
-func writeConfig(t *testing.T, dir, model string) string {
-	t.Helper()
-	path := filepath.Join(dir, "config.yaml")
-	config := fmt.Sprintf(`llm:
-  endpoint: %s
-  auth:
-    api_key: %s
-  model: %s
-`, testEndpoint, testAPIKey, model)
-	require.NoError(t, os.WriteFile(path, []byte(config), 0o600))
-	return path
-}
-
-func resolveRepoRoot(t *testing.T) string {
-	t.Helper()
-	workDir, err := os.Getwd()
-	require.NoError(t, err)
-	root, err := filepath.Abs(filepath.Join(workDir, "../.."))
-	require.NoError(t, err)
-	return root
-}
-
-func buildBinary(t *testing.T, ctx context.Context, repoRoot, dir string) string {
-	t.Helper()
-	binPath := filepath.Join(dir, "agn")
-	buildCmd := exec.CommandContext(ctx, "go", "build", "-o", binPath, "./cmd/agn")
-	buildCmd.Dir = repoRoot
-	buildOutput, err := buildCmd.CombinedOutput()
-	require.NoError(t, err, "go build failed: %s", strings.TrimSpace(string(buildOutput)))
-	return binPath
-}
-
-func runAgnExec(ctx context.Context, binPath, homeDir, configPath, prompt, conversationID string) (string, string, error) {
-	args := []string{"exec", prompt}
-	if strings.TrimSpace(conversationID) != "" {
-		args = append(args, "--conversation-id", conversationID)
+	stdout, stderr := runAgn(t, binary, env.env, "exec", "--thread-id", threadID, "hello")
+	if strings.TrimSpace(stdout) != "echo: hello" {
+		t.Fatalf("expected hello response, got %q", stdout)
 	}
-	cmd := exec.CommandContext(ctx, binPath, args...)
-	cmd.Env = append(filteredEnv(os.Environ(), "HOME", "AGN_CONFIG_PATH", "AGN_MCP_COMMAND"),
-		"HOME="+homeDir,
-		"AGN_CONFIG_PATH="+configPath,
-		"AGN_MCP_COMMAND=",
-	)
+	if parseThreadID(t, stderr) != threadID {
+		t.Fatalf("expected thread_id %q in stderr, got %q", threadID, stderr)
+	}
+	statePath := filepath.Join(env.home, ".agyn", "agn", "threads", threadID+".json")
+	if _, err := os.Stat(statePath); err != nil {
+		t.Fatalf("expected thread file to exist: %v", err)
+	}
+
+	stdout, stderr = runAgn(t, binary, env.env, "exec", "--thread-id", threadID, "again")
+	if strings.TrimSpace(stdout) != "echo: again" {
+		t.Fatalf("expected again response, got %q", stdout)
+	}
+	if parseThreadID(t, stderr) != threadID {
+		t.Fatalf("expected thread_id %q in stderr, got %q", threadID, stderr)
+	}
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		t.Fatalf("read thread file: %v", err)
+	}
+	var persisted struct {
+		Messages []json.RawMessage `json:"messages"`
+	}
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		t.Fatalf("parse thread file: %v", err)
+	}
+	if len(persisted.Messages) != 4 {
+		t.Fatalf("expected 4 messages, got %d", len(persisted.Messages))
+	}
+}
+
+func TestExecResume(t *testing.T) {
+	server := newStubServer(t)
+	defer server.Close()
+
+	env := newTestEnv(t, server.URL)
+	binary := buildAgnBinary(t)
+
+	_, stderr := runAgn(t, binary, env.env, "exec", "hi")
+	threadID := parseThreadID(t, stderr)
+
+	stdout, stderr := runAgn(t, binary, env.env, "exec", "resume", threadID, "fine")
+	if strings.TrimSpace(stdout) != "echo: fine" {
+		t.Fatalf("expected fine response, got %q", stdout)
+	}
+	if parseThreadID(t, stderr) != threadID {
+		t.Fatalf("expected thread_id %q in stderr, got %q", threadID, stderr)
+	}
+}
+
+func newStubServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			http.NotFound(w, r)
+			return
+		}
+		if r.Method != http.MethodPost {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		var req responseRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		prompt := lastUserPrompt(req.Input)
+		response := map[string]any{
+			"id": "resp-id",
+			"output": []any{
+				map[string]any{
+					"type": "message",
+					"role": "assistant",
+					"content": []any{
+						map[string]any{"type": "output_text", "text": fmt.Sprintf("echo: %s", prompt)},
+					},
+				},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+	})
+	return httptest.NewServer(handler)
+}
+
+type responseRequest struct {
+	Input json.RawMessage `json:"input"`
+}
+
+func lastUserPrompt(input json.RawMessage) string {
+	var messages []map[string]any
+	if err := json.Unmarshal(input, &messages); err != nil {
+		return ""
+	}
+	for i := len(messages) - 1; i >= 0; i-- {
+		role, _ := messages[i]["role"].(string)
+		if role != "user" {
+			continue
+		}
+		if text := extractInputText(messages[i]["content"]); text != "" {
+			return text
+		}
+	}
+	return ""
+}
+
+func extractInputText(content any) string {
+	switch typed := content.(type) {
+	case string:
+		return strings.TrimSpace(typed)
+	case []any:
+		for _, entry := range typed {
+			if text := extractInputText(entry); text != "" {
+				return text
+			}
+		}
+	case map[string]any:
+		if text, ok := typed["text"].(string); ok {
+			return strings.TrimSpace(text)
+		}
+		if text, ok := typed["input_text"].(string); ok {
+			return strings.TrimSpace(text)
+		}
+		if nested, ok := typed["content"]; ok {
+			return extractInputText(nested)
+		}
+	}
+	return ""
+}
+
+func newTestEnv(t *testing.T, endpoint string) testEnv {
+	t.Helper()
+	home := t.TempDir()
+	configPath := filepath.Join(home, "config.yaml")
+	config := fmt.Sprintf("llm:\n  endpoint: %s\n  model: test-model\n  auth:\n    api_key: test-key\n", endpoint)
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	env := append(os.Environ(), "HOME="+home, "AGN_CONFIG_PATH="+configPath, "AGN_MCP_COMMAND=")
+	return testEnv{home: home, env: env}
+}
+
+func buildAgnBinary(t *testing.T) string {
+	t.Helper()
+	buildOnce.Do(func() {
+		repoRoot, err := repoRoot()
+		if err != nil {
+			buildErr = err
+			return
+		}
+		dir, err := os.MkdirTemp("", "agn-e2e-")
+		if err != nil {
+			buildErr = err
+			return
+		}
+		agnBinary = filepath.Join(dir, "agn")
+		cmd := exec.Command("go", "build", "-o", agnBinary, "./cmd/agn")
+		cmd.Dir = repoRoot
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			buildErr = fmt.Errorf("build agn: %w: %s", err, strings.TrimSpace(string(output)))
+		}
+	})
+	if buildErr != nil {
+		t.Fatalf("build agn: %v", buildErr)
+	}
+	return agnBinary
+}
+
+func repoRoot() (string, error) {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(wd, "..", "..")), nil
+}
+
+func runAgn(t *testing.T, binary string, env []string, args ...string) (string, string) {
+	t.Helper()
+	cmd := exec.Command(binary, args...)
+	cmd.Env = env
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
-	err := cmd.Run()
-	return stdout.String(), stderr.String(), err
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("run agn %v: %v\nstdout: %s\nstderr: %s", args, err, stdout.String(), stderr.String())
+	}
+	return stdout.String(), stderr.String()
 }
 
-func parseConversationID(t *testing.T, stderr string) string {
+func parseThreadID(t *testing.T, stderr string) string {
 	t.Helper()
-	lines := strings.Split(stderr, "\n")
-	for _, line := range lines {
-		line = strings.TrimSpace(line)
-		if strings.HasPrefix(line, "conversation_id:") {
-			id := strings.TrimSpace(strings.TrimPrefix(line, "conversation_id:"))
-			require.NotEmpty(t, id, "conversation id is empty")
-			return id
+	for _, line := range strings.Split(stderr, "\n") {
+		if strings.HasPrefix(line, "thread_id:") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "thread_id:"))
 		}
 	}
-	require.Fail(t, "conversation id not found", "stderr: %s", stderr)
+	t.Fatalf("thread_id not found in stderr: %q", stderr)
 	return ""
-}
-
-func filteredEnv(env []string, keys ...string) []string {
-	filtered := make([]string, 0, len(env))
-	for _, entry := range env {
-		if shouldSkipEnv(entry, keys) {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
-}
-
-func shouldSkipEnv(entry string, keys []string) bool {
-	for _, key := range keys {
-		if strings.HasPrefix(entry, key+"=") {
-			return true
-		}
-	}
-	return false
 }


### PR DESCRIPTION
## Summary
- rename conversation state to threads with legacy read support and listing
- update loop/server/SDK for thread IDs, turn events, and typed notifications
- add exec resume CLI flow and expand e2e coverage

## Testing
- `go vet ./...`
- `go test ./...`
- `go build ./...`
- `go test -v -count=1 -tags e2e ./test/e2e/`

#19