### PR TITLE
Add e2e system prompt test

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -3,6 +3,7 @@ version: v2beta1
 vars:
   AGN_NAMESPACE: platform
   E2E_IMAGE: ghcr.io/agynio/devcontainer-go:1
+  TESTLLM_ENDPOINT: ${TESTLLM_ENDPOINT}
 
 deployments:
   e2e-runner:
@@ -116,7 +117,8 @@ pipelines:
       exec_container \
         --label-selector "app.kubernetes.io/name=agn-e2e" \
         -n ${AGN_NAMESPACE} \
-        -- bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
+        -- env TESTLLM_ENDPOINT="${TESTLLM_ENDPOINT}" \
+          bash -c 'cd /opt/app/data && go test -v -count=1 -tags e2e ./test/e2e/'
       EXIT_CODE=$?
       stop_dev e2e-runner
       purge_deployments e2e-runner

--- a/test/e2e/agent_system_prompt_test.go
+++ b/test/e2e/agent_system_prompt_test.go
@@ -1,0 +1,43 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/agynio/agn-cli/internal/llm"
+	"github.com/agynio/agn-cli/internal/loop"
+	"github.com/agynio/agn-cli/internal/message"
+	"github.com/agynio/agn-cli/internal/state"
+	"github.com/agynio/agn-cli/internal/summarize"
+)
+
+func TestAgentSystemPrompt(t *testing.T) {
+	cfg := loadTestConfig(t)
+
+	llmClient, err := llm.NewClient(cfg.Endpoint, cfg.APIKey, cfg.Model)
+	require.NoError(t, err)
+
+	store, err := state.NewLocalStore(t.TempDir())
+	require.NoError(t, err)
+
+	summarizer, err := summarize.New(llmClient, summarize.Config{})
+	require.NoError(t, err)
+
+	agent, err := loop.NewAgent(loop.AgentConfig{
+		Store:        store,
+		LLM:          llmClient,
+		Summarizer:   summarizer,
+		MCP:          nil,
+		SystemPrompt: "You are personal assistant",
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	result, err := agent.Run(ctx, loop.Input{Prompt: message.NewHumanMessage("hi")})
+	require.NoError(t, err)
+	require.Equal(t, "Hello! I am here to help!", result.Response)
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -2,8 +2,41 @@
 
 package e2e
 
-import "testing"
+import (
+	"os"
+	"strings"
+	"testing"
+)
 
-func TestPlaceholder(t *testing.T) {
-	t.Log("e2e placeholder")
+type testConfig struct {
+	Endpoint string
+	APIKey   string
+	Model    string
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func loadTestConfig(t *testing.T) testConfig {
+	t.Helper()
+
+	endpoint := strings.TrimSpace(os.Getenv("TESTLLM_ENDPOINT"))
+	if endpoint == "" {
+		t.Fatal("TESTLLM_ENDPOINT is required")
+	}
+
+	return testConfig{
+		Endpoint: endpoint,
+		APIKey:   envOrDefault("TESTLLM_API_KEY", "e2e-dummy-key"),
+		Model:    envOrDefault("TESTLLM_MODEL", "system-prompt"),
+	}
+}
+
+func envOrDefault(key, fallback string) string {
+	value := strings.TrimSpace(os.Getenv(key))
+	if value == "" {
+		return fallback
+	}
+	return value
 }


### PR DESCRIPTION
## Summary
- replace e2e placeholder with config-driven TestMain
- add system prompt agent loop e2e test using TestLLM
- pass TESTLLM_ENDPOINT through devspace e2e pipeline

## Testing
- go vet ./...
- go test ./...

## Issue
- #24