### PR TITLE
fix(release): align binary job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,29 +81,34 @@ jobs:
           echo "Manifest $IMAGE_NAME:$TAG includes linux/amd64 and linux/arm64"
 
   binary:
-    name: Build and release binary
+    name: Build and release binaries
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.24.x'
 
       - name: Build binaries
-        env:
-          CGO_ENABLED: 0
         run: |
           mkdir -p dist
-          GOOS=linux GOARCH=amd64 go build -trimpath -ldflags="-s -w" -o dist/agn-linux-amd64 ./cmd/agn
-          GOOS=linux GOARCH=arm64 go build -trimpath -ldflags="-s -w" -o dist/agn-linux-arm64 ./cmd/agn
+          for ARCH in amd64 arm64; do
+            CGO_ENABLED=0 GOOS=linux GOARCH="$ARCH" \
+              go build -trimpath -ldflags "-s -w" \
+              -o "dist/agn-linux-${ARCH}" ./cmd/agn
+          done
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
+          name: ${{ github.ref_name }}
+          tag_name: ${{ github.ref_name }}
           files: |
             dist/agn-linux-amd64
             dist/agn-linux-arm64


### PR DESCRIPTION
## Summary
- align the binary release job with the agynd-cli pattern
- build linux amd64/arm64 artifacts with release metadata

## Testing
- go vet ./...
- go test ./...
- go build ./...
- go test -v -count=1 -tags e2e ./test/e2e/

Closes #29