### PR TITLE
Remove dead MCP env from e2e tests

### DIFF
--- a/test/e2e/agent_summarization_test.go
+++ b/test/e2e/agent_summarization_test.go
@@ -86,7 +86,7 @@ func newSummarizationTestEnv(t *testing.T) summarizationTestEnv {
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(turn2Path, turn2Payload, 0o600))
 
-	base := append(os.Environ(), "HOME="+home, "AGN_MCP_COMMAND=")
+	base := append(os.Environ(), "HOME="+home)
 	return summarizationTestEnv{
 		turn1: append(append([]string{}, base...), "AGN_CONFIG_PATH="+turn1Path),
 		turn2: append(append([]string{}, base...), "AGN_CONFIG_PATH="+turn2Path),

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -109,7 +109,7 @@ func newTestEnv(t *testing.T, model string, systemPrompt string) testEnv {
 	payload, err := yaml.Marshal(configData)
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(configPath, payload, 0o600))
-	env := append(os.Environ(), "HOME="+home, "AGN_CONFIG_PATH="+configPath, "AGN_MCP_COMMAND=")
+	env := append(os.Environ(), "HOME="+home, "AGN_CONFIG_PATH="+configPath)
 	return testEnv{home: home, env: env}
 }
 


### PR DESCRIPTION
## Summary
- remove AGN_MCP_COMMAND from e2e test env setup

## Testing
- go vet ./...
- go test ./...
- go test -v -count=1 -tags e2e ./test/e2e/

Closes #36