### PR TITLE
feat(loop): make max steps configurable

### DIFF
--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -21,12 +22,15 @@ import (
 	"github.com/agynio/agn-cli/internal/telemetry"
 )
 
+const loopMaxStepsEnvVar = "AGN_LOOP_MAX_STEPS"
+
 func main() {
 	root := &cobra.Command{
 		Use:          "agn",
 		Short:        "Agent loop CLI",
 		SilenceUsage: true,
 	}
+	root.PersistentFlags().Int("max-steps", loop.DefaultMaxSteps, "Maximum loop steps")
 	root.AddCommand(execCommand(), serveCommand())
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -49,7 +53,11 @@ func execCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			agent, _, cleanup, err := buildAgent(cmd.Context(), cfg)
+			maxSteps, err := resolveMaxSteps(cmd, cfg)
+			if err != nil {
+				return err
+			}
+			agent, _, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
 			}
@@ -95,7 +103,11 @@ func execResumeCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg)
+			maxSteps, err := resolveMaxSteps(cmd, cfg)
+			if err != nil {
+				return err
+			}
+			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
 			}
@@ -150,7 +162,11 @@ func serveCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg)
+			maxSteps, err := resolveMaxSteps(cmd, cfg)
+			if err != nil {
+				return err
+			}
+			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
 			}
@@ -162,7 +178,40 @@ func serveCommand() *cobra.Command {
 	return cmd
 }
 
-func buildAgent(ctx context.Context, cfg config.Config) (*loop.Agent, state.Store, func(), error) {
+func resolveMaxSteps(cmd *cobra.Command, cfg config.Config) (int, error) {
+	flag := cmd.Flags().Lookup("max-steps")
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup("max-steps")
+	}
+	if flag != nil && flag.Changed {
+		value, err := strconv.Atoi(flag.Value.String())
+		if err != nil {
+			return 0, fmt.Errorf("--max-steps must be an integer >= 1")
+		}
+		return validateMaxSteps(value, "--max-steps")
+	}
+	envValue := strings.TrimSpace(os.Getenv(loopMaxStepsEnvVar))
+	if envValue != "" {
+		value, err := strconv.Atoi(envValue)
+		if err != nil {
+			return 0, fmt.Errorf("%s must be an integer >= 1", loopMaxStepsEnvVar)
+		}
+		return validateMaxSteps(value, loopMaxStepsEnvVar)
+	}
+	if cfg.Loop.MaxSteps != nil {
+		return *cfg.Loop.MaxSteps, nil
+	}
+	return loop.DefaultMaxSteps, nil
+}
+
+func validateMaxSteps(value int, source string) (int, error) {
+	if value < 1 {
+		return 0, fmt.Errorf("%s must be >= 1", source)
+	}
+	return value, nil
+}
+
+func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Agent, state.Store, func(), error) {
 	tracerProvider, err := telemetry.Init(ctx)
 	if err != nil {
 		return nil, nil, func() {}, err
@@ -229,6 +278,7 @@ func buildAgent(ctx context.Context, cfg config.Config) (*loop.Agent, state.Stor
 		Summarizer:   summarizer,
 		MCP:          mcpProvider,
 		SystemPrompt: cfg.SystemPrompt,
+		MaxSteps:     maxSteps,
 		Tracer:       tracer,
 	})
 	if err != nil {

--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 	"time"
 
@@ -22,15 +21,12 @@ import (
 	"github.com/agynio/agn-cli/internal/telemetry"
 )
 
-const loopMaxStepsEnvVar = "AGN_LOOP_MAX_STEPS"
-
 func main() {
 	root := &cobra.Command{
 		Use:          "agn",
 		Short:        "Agent loop CLI",
 		SilenceUsage: true,
 	}
-	root.PersistentFlags().Int("max-steps", loop.DefaultMaxSteps, "Maximum loop steps")
 	root.AddCommand(execCommand(), serveCommand())
 	if err := root.Execute(); err != nil {
 		os.Exit(1)
@@ -53,10 +49,7 @@ func execCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			maxSteps, err := resolveMaxSteps(cmd, cfg)
-			if err != nil {
-				return err
-			}
+			maxSteps := resolveMaxSteps(cfg)
 			agent, _, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
@@ -103,10 +96,7 @@ func execResumeCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			maxSteps, err := resolveMaxSteps(cmd, cfg)
-			if err != nil {
-				return err
-			}
+			maxSteps := resolveMaxSteps(cfg)
 			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
@@ -162,10 +152,7 @@ func serveCommand() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			maxSteps, err := resolveMaxSteps(cmd, cfg)
-			if err != nil {
-				return err
-			}
+			maxSteps := resolveMaxSteps(cfg)
 			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
@@ -178,33 +165,11 @@ func serveCommand() *cobra.Command {
 	return cmd
 }
 
-func resolveMaxSteps(cmd *cobra.Command, cfg config.Config) (int, error) {
-	if cmd.Flags().Changed("max-steps") {
-		value, err := cmd.Flags().GetInt("max-steps")
-		if err != nil {
-			return 0, err
-		}
-		return validateMaxSteps(value, "--max-steps")
-	}
-	envValue := strings.TrimSpace(os.Getenv(loopMaxStepsEnvVar))
-	if envValue != "" {
-		value, err := strconv.Atoi(envValue)
-		if err != nil {
-			return 0, fmt.Errorf("%s must be an integer >= 1", loopMaxStepsEnvVar)
-		}
-		return validateMaxSteps(value, loopMaxStepsEnvVar)
-	}
+func resolveMaxSteps(cfg config.Config) int {
 	if cfg.Loop.MaxSteps != nil {
-		return *cfg.Loop.MaxSteps, nil
+		return *cfg.Loop.MaxSteps
 	}
-	return loop.DefaultMaxSteps, nil
-}
-
-func validateMaxSteps(value int, source string) (int, error) {
-	if value < 1 {
-		return 0, fmt.Errorf("%s must be >= 1", source)
-	}
-	return value, nil
+	return loop.DefaultMaxSteps
 }
 
 func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Agent, state.Store, func(), error) {

--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -179,14 +179,10 @@ func serveCommand() *cobra.Command {
 }
 
 func resolveMaxSteps(cmd *cobra.Command, cfg config.Config) (int, error) {
-	flag := cmd.Flags().Lookup("max-steps")
-	if flag == nil {
-		flag = cmd.InheritedFlags().Lookup("max-steps")
-	}
-	if flag != nil && flag.Changed {
-		value, err := strconv.Atoi(flag.Value.String())
+	if cmd.Flags().Changed("max-steps") {
+		value, err := cmd.Flags().GetInt("max-steps")
 		if err != nil {
-			return 0, fmt.Errorf("--max-steps must be an integer >= 1")
+			return 0, err
 		}
 		return validateMaxSteps(value, "--max-steps")
 	}

--- a/cmd/agn/main_test.go
+++ b/cmd/agn/main_test.go
@@ -3,76 +3,20 @@ package main
 import (
 	"testing"
 
-	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 
 	"github.com/agynio/agn-cli/internal/config"
 	"github.com/agynio/agn-cli/internal/loop"
 )
 
-func newTestCommand() *cobra.Command {
-	cmd := &cobra.Command{Use: "agn"}
-	cmd.Flags().Int("max-steps", loop.DefaultMaxSteps, "Maximum loop steps")
-	return cmd
-}
-
 func TestResolveMaxStepsDefault(t *testing.T) {
-	cmd := newTestCommand()
-	t.Setenv(loopMaxStepsEnvVar, "")
-
-	maxSteps, err := resolveMaxSteps(cmd, config.Config{})
-	require.NoError(t, err)
+	maxSteps := resolveMaxSteps(config.Config{})
 	require.Equal(t, loop.DefaultMaxSteps, maxSteps)
 }
 
 func TestResolveMaxStepsConfig(t *testing.T) {
-	cmd := newTestCommand()
-	t.Setenv(loopMaxStepsEnvVar, "")
 	value := 321
 	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
-
-	maxSteps, err := resolveMaxSteps(cmd, cfg)
-	require.NoError(t, err)
+	maxSteps := resolveMaxSteps(cfg)
 	require.Equal(t, value, maxSteps)
-}
-
-func TestResolveMaxStepsEnvOverridesConfig(t *testing.T) {
-	cmd := newTestCommand()
-	t.Setenv(loopMaxStepsEnvVar, "456")
-	value := 321
-	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
-
-	maxSteps, err := resolveMaxSteps(cmd, cfg)
-	require.NoError(t, err)
-	require.Equal(t, 456, maxSteps)
-}
-
-func TestResolveMaxStepsFlagOverridesEnv(t *testing.T) {
-	cmd := newTestCommand()
-	t.Setenv(loopMaxStepsEnvVar, "456")
-	value := 321
-	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
-	require.NoError(t, cmd.Flags().Set("max-steps", "789"))
-
-	maxSteps, err := resolveMaxSteps(cmd, cfg)
-	require.NoError(t, err)
-	require.Equal(t, 789, maxSteps)
-}
-
-func TestResolveMaxStepsEnvInvalid(t *testing.T) {
-	cmd := newTestCommand()
-	t.Setenv(loopMaxStepsEnvVar, "nope")
-
-	_, err := resolveMaxSteps(cmd, config.Config{})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "AGN_LOOP_MAX_STEPS must be an integer >= 1")
-}
-
-func TestResolveMaxStepsFlagInvalid(t *testing.T) {
-	cmd := newTestCommand()
-	require.NoError(t, cmd.Flags().Set("max-steps", "0"))
-
-	_, err := resolveMaxSteps(cmd, config.Config{})
-	require.Error(t, err)
-	require.ErrorContains(t, err, "--max-steps must be >= 1")
 }

--- a/cmd/agn/main_test.go
+++ b/cmd/agn/main_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/require"
+
+	"github.com/agynio/agn-cli/internal/config"
+	"github.com/agynio/agn-cli/internal/loop"
+)
+
+func newTestCommand() *cobra.Command {
+	cmd := &cobra.Command{Use: "agn"}
+	cmd.Flags().Int("max-steps", loop.DefaultMaxSteps, "Maximum loop steps")
+	return cmd
+}
+
+func TestResolveMaxStepsDefault(t *testing.T) {
+	cmd := newTestCommand()
+	t.Setenv(loopMaxStepsEnvVar, "")
+
+	maxSteps, err := resolveMaxSteps(cmd, config.Config{})
+	require.NoError(t, err)
+	require.Equal(t, loop.DefaultMaxSteps, maxSteps)
+}
+
+func TestResolveMaxStepsConfig(t *testing.T) {
+	cmd := newTestCommand()
+	t.Setenv(loopMaxStepsEnvVar, "")
+	value := 321
+	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
+
+	maxSteps, err := resolveMaxSteps(cmd, cfg)
+	require.NoError(t, err)
+	require.Equal(t, value, maxSteps)
+}
+
+func TestResolveMaxStepsEnvOverridesConfig(t *testing.T) {
+	cmd := newTestCommand()
+	t.Setenv(loopMaxStepsEnvVar, "456")
+	value := 321
+	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
+
+	maxSteps, err := resolveMaxSteps(cmd, cfg)
+	require.NoError(t, err)
+	require.Equal(t, 456, maxSteps)
+}
+
+func TestResolveMaxStepsFlagOverridesEnv(t *testing.T) {
+	cmd := newTestCommand()
+	t.Setenv(loopMaxStepsEnvVar, "456")
+	value := 321
+	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
+	require.NoError(t, cmd.Flags().Set("max-steps", "789"))
+
+	maxSteps, err := resolveMaxSteps(cmd, cfg)
+	require.NoError(t, err)
+	require.Equal(t, 789, maxSteps)
+}
+
+func TestResolveMaxStepsEnvInvalid(t *testing.T) {
+	cmd := newTestCommand()
+	t.Setenv(loopMaxStepsEnvVar, "nope")
+
+	_, err := resolveMaxSteps(cmd, config.Config{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "AGN_LOOP_MAX_STEPS must be an integer >= 1")
+}
+
+func TestResolveMaxStepsFlagInvalid(t *testing.T) {
+	cmd := newTestCommand()
+	require.NoError(t, cmd.Flags().Set("max-steps", "0"))
+
+	_, err := resolveMaxSteps(cmd, config.Config{})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "--max-steps must be >= 1")
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -17,6 +17,7 @@ const configEnvVar = "AGN_CONFIG_PATH"
 type Config struct {
 	LLM           LLMConfig           `yaml:"llm"`
 	SystemPrompt  string              `yaml:"system_prompt"`
+	Loop          LoopConfig          `yaml:"loop"`
 	Summarization SummarizationConfig `yaml:"summarization"`
 	MCP           MCPConfig           `yaml:"mcp"`
 }
@@ -31,6 +32,10 @@ type SummarizationConfig struct {
 	LLM        *LLMConfig `yaml:"llm"`
 	KeepTokens int        `yaml:"keep_tokens"`
 	MaxTokens  int        `yaml:"max_tokens"`
+}
+
+type LoopConfig struct {
+	MaxSteps *int `yaml:"max_steps"`
 }
 
 type AuthConfig struct {
@@ -96,6 +101,9 @@ func (c Config) Validate() error {
 	if err := c.Summarization.Validate(); err != nil {
 		return err
 	}
+	if err := c.Loop.Validate(); err != nil {
+		return err
+	}
 	if err := c.MCP.Validate(); err != nil {
 		return err
 	}
@@ -125,6 +133,16 @@ func (s SummarizationConfig) Validate() error {
 	}
 	if err := s.LLM.Validate(); err != nil {
 		return fmt.Errorf("summarization.%s", err)
+	}
+	return nil
+}
+
+func (l LoopConfig) Validate() error {
+	if l.MaxSteps == nil {
+		return nil
+	}
+	if *l.MaxSteps < 1 {
+		return errors.New("loop.max_steps must be >= 1")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -112,6 +112,41 @@ summarization:
 	require.Equal(t, 20, cfg.Summarization.MaxTokens)
 }
 
+func TestLoadConfigWithLoopMaxSteps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`llm:
+  endpoint: https://api.openai.com/v1
+  auth:
+    api_key: sk-test
+  model: gpt-4.1
+loop:
+  max_steps: 500
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Loop.MaxSteps)
+	require.Equal(t, 500, *cfg.Loop.MaxSteps)
+}
+
+func TestLoadConfigWithInvalidLoopMaxSteps(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`llm:
+  endpoint: https://api.openai.com/v1
+  auth:
+    api_key: sk-test
+  model: gpt-4.1
+loop:
+  max_steps: 0
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "loop.max_steps must be >= 1")
+}
+
 func TestLoadConfigInvalidSummarizationLLM(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	content := []byte(`llm:

--- a/internal/loop/agent.go
+++ b/internal/loop/agent.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	defaultMaxSteps            = 20
+	DefaultMaxSteps            = 1000
 	defaultMaxRestrictAttempts = 2
 )
 
@@ -111,7 +111,7 @@ func NewAgent(cfg AgentConfig) (*Agent, error) {
 	}
 	maxSteps := cfg.MaxSteps
 	if maxSteps <= 0 {
-		maxSteps = defaultMaxSteps
+		maxSteps = DefaultMaxSteps
 	}
 	maxRestrict := cfg.MaxRestrictAttempts
 	if maxRestrict <= 0 {

--- a/internal/loop/agent.go
+++ b/internal/loop/agent.go
@@ -111,7 +111,7 @@ func NewAgent(cfg AgentConfig) (*Agent, error) {
 	}
 	maxSteps := cfg.MaxSteps
 	if maxSteps <= 0 {
-		maxSteps = DefaultMaxSteps
+		return nil, errors.New("max steps must be >= 1")
 	}
 	maxRestrict := cfg.MaxRestrictAttempts
 	if maxRestrict <= 0 {


### PR DESCRIPTION
## Summary
- add `loop.max_steps` config field with validation and default **1000**
- wire configured max steps into agent loop setup

## Testing
- go test ./...
- go vet ./...

Closes #52