### PR TITLE
feat: add built-in shell tool

### DIFF
--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -228,7 +228,7 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 		cleanup()
 		return nil, nil, func() {}, err
 	}
-	mcpProvider, err = newMCPProvider(ctx, cfg.MCP)
+	mcpProvider, err = newToolProvider(ctx, cfg.Tools, cfg.MCP)
 	if err != nil {
 		cleanup()
 		return nil, nil, func() {}, err
@@ -247,6 +247,36 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 		return nil, nil, func() {}, err
 	}
 	return agent, store, cleanup, nil
+}
+
+func newToolProvider(ctx context.Context, toolsCfg config.ToolsConfig, mcpCfg config.MCPConfig) (mcp.ToolProvider, error) {
+	providers := make([]mcp.ToolProvider, 0, 2)
+
+	if toolsCfg.Shell.EnabledValue() {
+		providers = append(providers, mcp.NewShellToolProvider(mcp.ShellToolConfig{
+			Timeout:        toolsCfg.Shell.Timeout,
+			IdleTimeout:    toolsCfg.Shell.IdleTimeout,
+			MaxTimeout:     toolsCfg.Shell.MaxTimeout,
+			MaxIdleTimeout: toolsCfg.Shell.MaxIdleTimeout,
+			MaxOutput:      toolsCfg.Shell.MaxOutput,
+		}))
+	}
+
+	mcpProvider, err := newMCPProvider(ctx, mcpCfg)
+	if err != nil {
+		return nil, err
+	}
+	if mcpProvider != nil {
+		mcpProvider = mcp.NewReservedToolProvider(mcpProvider, []string{mcp.ShellToolName})
+		providers = append(providers, mcpProvider)
+	}
+	if len(providers) == 0 {
+		return nil, nil
+	}
+	if len(providers) == 1 {
+		return providers[0], nil
+	}
+	return mcp.NewMultiClient(providers)
 }
 
 func newMCPProvider(ctx context.Context, cfg config.MCPConfig) (mcp.ToolProvider, error) {

--- a/cmd/agn/main_test.go
+++ b/cmd/agn/main_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/agynio/agn-cli/internal/config"
 	"github.com/agynio/agn-cli/internal/loop"
+	"github.com/agynio/agn-cli/internal/mcp"
 )
 
 func TestResolveMaxStepsDefault(t *testing.T) {
@@ -19,4 +21,26 @@ func TestResolveMaxStepsConfig(t *testing.T) {
 	cfg := config.Config{Loop: config.LoopConfig{MaxSteps: &value}}
 	maxSteps := resolveMaxSteps(cfg)
 	require.Equal(t, value, maxSteps)
+}
+
+func TestNewToolProviderShellEnabled(t *testing.T) {
+	provider, err := newToolProvider(context.Background(), config.ToolsConfig{}, config.MCPConfig{})
+	require.NoError(t, err)
+	require.NotNil(t, provider)
+
+	tools, err := provider.ListTools(context.Background())
+	require.NoError(t, err)
+	require.Len(t, tools, 1)
+	require.Equal(t, mcp.ShellToolName, tools[0].Name)
+}
+
+func TestNewToolProviderShellDisabled(t *testing.T) {
+	disabled := false
+	provider, err := newToolProvider(
+		context.Background(),
+		config.ToolsConfig{Shell: config.ShellToolConfig{Enabled: &disabled}},
+		config.MCPConfig{},
+	)
+	require.NoError(t, err)
+	require.Nil(t, provider)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	SystemPrompt  string              `yaml:"system_prompt"`
 	Loop          LoopConfig          `yaml:"loop"`
 	Summarization SummarizationConfig `yaml:"summarization"`
+	Tools         ToolsConfig         `yaml:"tools"`
 	MCP           MCPConfig           `yaml:"mcp"`
 }
 
@@ -32,6 +33,19 @@ type SummarizationConfig struct {
 	LLM        *LLMConfig `yaml:"llm"`
 	KeepTokens int        `yaml:"keep_tokens"`
 	MaxTokens  int        `yaml:"max_tokens"`
+}
+
+type ToolsConfig struct {
+	Shell ShellToolConfig `yaml:"shell"`
+}
+
+type ShellToolConfig struct {
+	Enabled        *bool `yaml:"enabled"`
+	Timeout        int   `yaml:"timeout"`
+	IdleTimeout    int   `yaml:"idle_timeout"`
+	MaxTimeout     int   `yaml:"max_timeout"`
+	MaxIdleTimeout int   `yaml:"max_idle_timeout"`
+	MaxOutput      int   `yaml:"max_output"`
 }
 
 type LoopConfig struct {
@@ -104,6 +118,9 @@ func (c Config) Validate() error {
 	if err := c.Loop.Validate(); err != nil {
 		return err
 	}
+	if err := c.Tools.Validate(); err != nil {
+		return err
+	}
 	if err := c.MCP.Validate(); err != nil {
 		return err
 	}
@@ -143,6 +160,36 @@ func (l LoopConfig) Validate() error {
 	}
 	if *l.MaxSteps < 1 {
 		return errors.New("loop.max_steps must be >= 1")
+	}
+	return nil
+}
+
+func (t ToolsConfig) Validate() error {
+	return t.Shell.Validate()
+}
+
+func (s ShellToolConfig) EnabledValue() bool {
+	if s.Enabled == nil {
+		return true
+	}
+	return *s.Enabled
+}
+
+func (s ShellToolConfig) Validate() error {
+	if s.Timeout < 0 {
+		return errors.New("tools.shell.timeout must be >= 0")
+	}
+	if s.IdleTimeout < 0 {
+		return errors.New("tools.shell.idle_timeout must be >= 0")
+	}
+	if s.MaxTimeout < 0 {
+		return errors.New("tools.shell.max_timeout must be >= 0")
+	}
+	if s.MaxIdleTimeout < 0 {
+		return errors.New("tools.shell.max_idle_timeout must be >= 0")
+	}
+	if s.MaxOutput < 0 {
+		return errors.New("tools.shell.max_output must be >= 0")
 	}
 	return nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -287,3 +287,69 @@ mcp:
 	require.Error(t, err)
 	require.ErrorContains(t, err, "mcp.servers.weather.exactly one of command or url is required")
 }
+
+func TestLoadConfigWithShellToolDefaults(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`llm:
+  endpoint: https://api.openai.com/v1
+  auth:
+    api_key: sk-test
+  model: gpt-4.1
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.True(t, cfg.Tools.Shell.EnabledValue())
+	require.Equal(t, 0, cfg.Tools.Shell.Timeout)
+	require.Equal(t, 0, cfg.Tools.Shell.IdleTimeout)
+	require.Equal(t, 0, cfg.Tools.Shell.MaxTimeout)
+	require.Equal(t, 0, cfg.Tools.Shell.MaxIdleTimeout)
+	require.Equal(t, 0, cfg.Tools.Shell.MaxOutput)
+}
+
+func TestLoadConfigWithShellToolSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`llm:
+  endpoint: https://api.openai.com/v1
+  auth:
+    api_key: sk-test
+  model: gpt-4.1
+tools:
+  shell:
+    enabled: false
+    timeout: 5
+    idle_timeout: 6
+    max_timeout: 10
+    max_idle_timeout: 12
+    max_output: 100
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	cfg, err := Load(path)
+	require.NoError(t, err)
+	require.False(t, cfg.Tools.Shell.EnabledValue())
+	require.Equal(t, 5, cfg.Tools.Shell.Timeout)
+	require.Equal(t, 6, cfg.Tools.Shell.IdleTimeout)
+	require.Equal(t, 10, cfg.Tools.Shell.MaxTimeout)
+	require.Equal(t, 12, cfg.Tools.Shell.MaxIdleTimeout)
+	require.Equal(t, 100, cfg.Tools.Shell.MaxOutput)
+}
+
+func TestLoadConfigWithInvalidShellToolSettings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	content := []byte(`llm:
+  endpoint: https://api.openai.com/v1
+  auth:
+    api_key: sk-test
+  model: gpt-4.1
+tools:
+  shell:
+    timeout: -1
+`)
+	require.NoError(t, os.WriteFile(path, content, 0o600))
+
+	_, err := Load(path)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "tools.shell.timeout must be >= 0")
+}

--- a/internal/mcp/reserved.go
+++ b/internal/mcp/reserved.go
@@ -1,0 +1,57 @@
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+type ReservedToolProvider struct {
+	provider ToolProvider
+	reserved map[string]struct{}
+}
+
+func NewReservedToolProvider(provider ToolProvider, reserved []string) *ReservedToolProvider {
+	index := make(map[string]struct{}, len(reserved))
+	for _, name := range reserved {
+		trimmed := strings.TrimSpace(name)
+		if trimmed == "" {
+			continue
+		}
+		index[trimmed] = struct{}{}
+	}
+	return &ReservedToolProvider{provider: provider, reserved: index}
+}
+
+func (r *ReservedToolProvider) ListTools(ctx context.Context) ([]Tool, error) {
+	tools, err := r.provider.ListTools(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.checkReserved(tools); err != nil {
+		return nil, err
+	}
+	return tools, nil
+}
+
+func (r *ReservedToolProvider) CallTool(ctx context.Context, call ToolCall) (ToolResult, error) {
+	name := strings.TrimSpace(call.Name)
+	if _, reserved := r.reserved[name]; reserved {
+		return ToolResult{}, fmt.Errorf("mcp tool name %q is reserved", name)
+	}
+	return r.provider.CallTool(ctx, call)
+}
+
+func (r *ReservedToolProvider) Close() error {
+	return r.provider.Close()
+}
+
+func (r *ReservedToolProvider) checkReserved(tools []Tool) error {
+	for _, tool := range tools {
+		name := strings.TrimSpace(tool.Name)
+		if _, reserved := r.reserved[name]; reserved {
+			return fmt.Errorf("mcp tool name %q is reserved", name)
+		}
+	}
+	return nil
+}

--- a/internal/mcp/reserved_test.go
+++ b/internal/mcp/reserved_test.go
@@ -1,0 +1,26 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReservedToolProviderRejectsReservedName(t *testing.T) {
+	provider := &fakeProvider{tools: []Tool{{Name: ShellToolName}}}
+	wrapper := NewReservedToolProvider(provider, []string{ShellToolName})
+
+	_, err := wrapper.ListTools(context.Background())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "reserved")
+}
+
+func TestReservedToolProviderAllowsOtherNames(t *testing.T) {
+	provider := &fakeProvider{tools: []Tool{{Name: "other"}}}
+	wrapper := NewReservedToolProvider(provider, []string{ShellToolName})
+
+	tools, err := wrapper.ListTools(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, []Tool{{Name: "other"}}, tools)
+}

--- a/internal/mcp/shell.go
+++ b/internal/mcp/shell.go
@@ -149,10 +149,6 @@ func resolveTimeoutSeconds(value *int, defaultValue int, maxValue int, field str
 }
 
 func executeShellCommand(ctx context.Context, shellPath string, input shellExecutionConfig) (shellExecutionResult, error) {
-	resolvedShell := strings.TrimSpace(shellPath)
-	if resolvedShell == "" {
-		resolvedShell = "/bin/sh"
-	}
 	var cancel context.CancelFunc
 	execCtx := ctx
 	if input.Timeout > 0 {
@@ -162,8 +158,8 @@ func executeShellCommand(ctx context.Context, shellPath string, input shellExecu
 	}
 	defer cancel()
 
-	cmd := exec.CommandContext(execCtx, resolvedShell, "-c", input.Command)
-	if strings.TrimSpace(input.Cwd) != "" {
+	cmd := exec.CommandContext(execCtx, shellPath, "-c", input.Command)
+	if input.Cwd != "" {
 		cmd.Dir = input.Cwd
 	}
 	stdoutPipe, err := cmd.StdoutPipe()
@@ -237,10 +233,7 @@ func executeShellCommand(ctx context.Context, shellPath string, input shellExecu
 			return shellExecutionResult{}, fmt.Errorf("run shell command: %w", waitErr)
 		}
 	}
-	exitCode := 0
-	if cmd.ProcessState != nil {
-		exitCode = cmd.ProcessState.ExitCode()
-	}
+	exitCode := cmd.ProcessState.ExitCode()
 
 	result := shellExecutionResult{
 		ExitCode: exitCode,
@@ -319,9 +312,7 @@ func (w *streamWriter) Write(p []byte) (int, error) {
 	if len(p) == 0 {
 		return 0, nil
 	}
-	if w.activity != nil {
-		w.activity()
-	}
+	w.activity()
 	if w.stdout {
 		return w.collector.WriteStdout(p)
 	}
@@ -361,10 +352,8 @@ func (o *outputCollector) write(p []byte, buffer *bytes.Buffer) (int, error) {
 
 	if o.truncated {
 		o.totalBytes += len(p)
-		if o.output != nil {
-			if _, err := o.output.Write(p); err != nil {
-				return 0, err
-			}
+		if _, err := o.output.Write(p); err != nil {
+			return 0, err
 		}
 		return len(p), nil
 	}
@@ -378,7 +367,7 @@ func (o *outputCollector) write(p []byte, buffer *bytes.Buffer) (int, error) {
 	newTotal := o.totalBytes + len(p)
 	if newTotal > o.maxOutput {
 		allowed := o.maxOutput - o.totalBytes
-		file, err := os.CreateTemp(os.TempDir(), "agn-shell-output-")
+		file, err := os.CreateTemp("", "agn-shell-output-")
 		if err != nil {
 			return 0, err
 		}

--- a/internal/mcp/shell.go
+++ b/internal/mcp/shell.go
@@ -1,0 +1,449 @@
+package mcp
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const ShellToolName = "shell"
+
+const shellToolDescription = "Execute a shell command."
+
+var shellToolSchema = []byte(`{"type":"object","properties":{"command":{"type":"string"},"cwd":{"type":"string"},"timeout":{"type":"integer","minimum":0},"idle_timeout":{"type":"integer","minimum":0}},"required":["command"]}`)
+
+type ShellToolConfig struct {
+	Timeout        int
+	IdleTimeout    int
+	MaxTimeout     int
+	MaxIdleTimeout int
+	MaxOutput      int
+}
+
+type ShellToolProvider struct {
+	config    ShellToolConfig
+	shellPath string
+}
+
+func NewShellToolProvider(config ShellToolConfig) *ShellToolProvider {
+	return &ShellToolProvider{config: config, shellPath: resolveShellPath()}
+}
+
+func (s *ShellToolProvider) ListTools(ctx context.Context) ([]Tool, error) {
+	return []Tool{{
+		Name:        ShellToolName,
+		Description: shellToolDescription,
+		InputSchema: shellToolSchema,
+	}}, nil
+}
+
+func (s *ShellToolProvider) CallTool(ctx context.Context, call ToolCall) (ToolResult, error) {
+	if call.Name != ShellToolName {
+		return ToolResult{}, fmt.Errorf("unknown tool name %q", call.Name)
+	}
+	input, err := parseShellArguments(call.Arguments, s.config)
+	if err != nil {
+		return ToolResult{}, err
+	}
+	result, err := executeShellCommand(ctx, s.shellPath, input)
+	if err != nil {
+		return ToolResult{}, err
+	}
+	payload, err := json.Marshal(result)
+	if err != nil {
+		return ToolResult{}, fmt.Errorf("marshal shell output: %w", err)
+	}
+	return ToolResult{Content: []ContentItem{{Type: ContentTypeText, Text: string(payload)}}}, nil
+}
+
+func (s *ShellToolProvider) Close() error {
+	return nil
+}
+
+type shellToolArguments struct {
+	Command     string  `json:"command"`
+	Cwd         *string `json:"cwd"`
+	Timeout     *int    `json:"timeout"`
+	IdleTimeout *int    `json:"idle_timeout"`
+}
+
+type shellExecutionConfig struct {
+	Command     string
+	Cwd         string
+	Timeout     time.Duration
+	IdleTimeout time.Duration
+	MaxOutput   int
+}
+
+type shellExecutionResult struct {
+	ExitCode        int    `json:"exit_code"`
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	OutputTruncated bool   `json:"output_truncated,omitempty"`
+	OutputBytes     int    `json:"output_bytes,omitempty"`
+	OutputFile      string `json:"output_file,omitempty"`
+}
+
+func parseShellArguments(raw json.RawMessage, cfg ShellToolConfig) (shellExecutionConfig, error) {
+	if len(raw) == 0 {
+		return shellExecutionConfig{}, errors.New("shell tool arguments are required")
+	}
+	var args shellToolArguments
+	if err := json.Unmarshal(raw, &args); err != nil {
+		return shellExecutionConfig{}, fmt.Errorf("parse shell tool arguments: %w", err)
+	}
+	command := strings.TrimSpace(args.Command)
+	if command == "" {
+		return shellExecutionConfig{}, errors.New("shell command is required")
+	}
+	cwd := ""
+	if args.Cwd != nil {
+		cwd = strings.TrimSpace(*args.Cwd)
+	}
+	if cfg.MaxOutput < 0 {
+		return shellExecutionConfig{}, errors.New("shell max_output must be >= 0")
+	}
+	timeoutSeconds, err := resolveTimeoutSeconds(args.Timeout, cfg.Timeout, cfg.MaxTimeout, "timeout")
+	if err != nil {
+		return shellExecutionConfig{}, err
+	}
+	idleSeconds, err := resolveTimeoutSeconds(args.IdleTimeout, cfg.IdleTimeout, cfg.MaxIdleTimeout, "idle_timeout")
+	if err != nil {
+		return shellExecutionConfig{}, err
+	}
+	return shellExecutionConfig{
+		Command:     command,
+		Cwd:         cwd,
+		Timeout:     time.Duration(timeoutSeconds) * time.Second,
+		IdleTimeout: time.Duration(idleSeconds) * time.Second,
+		MaxOutput:   cfg.MaxOutput,
+	}, nil
+}
+
+func resolveTimeoutSeconds(value *int, defaultValue int, maxValue int, field string) (int, error) {
+	resolved := defaultValue
+	if value != nil {
+		resolved = *value
+	}
+	if resolved < 0 {
+		return 0, fmt.Errorf("shell %s must be >= 0", field)
+	}
+	if maxValue < 0 {
+		return 0, fmt.Errorf("shell max_%s must be >= 0", field)
+	}
+	if maxValue > 0 {
+		if resolved == 0 || resolved > maxValue {
+			resolved = maxValue
+		}
+	}
+	return resolved, nil
+}
+
+func executeShellCommand(ctx context.Context, shellPath string, input shellExecutionConfig) (shellExecutionResult, error) {
+	resolvedShell := strings.TrimSpace(shellPath)
+	if resolvedShell == "" {
+		resolvedShell = "/bin/sh"
+	}
+	var cancel context.CancelFunc
+	execCtx := ctx
+	if input.Timeout > 0 {
+		execCtx, cancel = context.WithTimeout(ctx, input.Timeout)
+	} else {
+		execCtx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(execCtx, resolvedShell, "-c", input.Command)
+	if strings.TrimSpace(input.Cwd) != "" {
+		cmd.Dir = input.Cwd
+	}
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return shellExecutionResult{}, fmt.Errorf("open stdout: %w", err)
+	}
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return shellExecutionResult{}, fmt.Errorf("open stderr: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return shellExecutionResult{}, fmt.Errorf("start shell command: %w", err)
+	}
+
+	collector := newOutputCollector(input.MaxOutput)
+	activityCh := make(chan struct{}, 1)
+	idleTriggered := atomic.Bool{}
+	stopIdle := startIdleTimer(execCtx, input.IdleTimeout, activityCh, func() {
+		idleTriggered.Store(true)
+		cancel()
+	})
+	defer stopIdle()
+
+	activity := func() {
+		if input.IdleTimeout <= 0 {
+			return
+		}
+		select {
+		case activityCh <- struct{}{}:
+		default:
+		}
+	}
+
+	errCh := make(chan error, 2)
+	go func() {
+		_, copyErr := io.Copy(&streamWriter{collector: collector, stdout: true, activity: activity}, stdoutPipe)
+		errCh <- copyErr
+	}()
+	go func() {
+		_, copyErr := io.Copy(&streamWriter{collector: collector, stdout: false, activity: activity}, stderrPipe)
+		errCh <- copyErr
+	}()
+
+	waitErr := cmd.Wait()
+	stdoutErr := <-errCh
+	stderrErr := <-errCh
+	closeErr := collector.Close()
+	stdoutErr = normalizePipeError(stdoutErr)
+	stderrErr = normalizePipeError(stderrErr)
+	if stdoutErr != nil {
+		return shellExecutionResult{}, fmt.Errorf("read stdout: %w", stdoutErr)
+	}
+	if stderrErr != nil {
+		return shellExecutionResult{}, fmt.Errorf("read stderr: %w", stderrErr)
+	}
+	if closeErr != nil {
+		return shellExecutionResult{}, fmt.Errorf("close output file: %w", closeErr)
+	}
+	if execCtx.Err() != nil {
+		if idleTriggered.Load() {
+			return shellExecutionResult{}, errors.New("shell command idle timeout exceeded")
+		}
+		if errors.Is(execCtx.Err(), context.DeadlineExceeded) {
+			return shellExecutionResult{}, errors.New("shell command timeout exceeded")
+		}
+		return shellExecutionResult{}, execCtx.Err()
+	}
+	if waitErr != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(waitErr, &exitErr) {
+			return shellExecutionResult{}, fmt.Errorf("run shell command: %w", waitErr)
+		}
+	}
+	exitCode := 0
+	if cmd.ProcessState != nil {
+		exitCode = cmd.ProcessState.ExitCode()
+	}
+
+	result := shellExecutionResult{
+		ExitCode: exitCode,
+		Stdout:   collector.Stdout(),
+		Stderr:   collector.Stderr(),
+	}
+	if collector.Truncated() {
+		result.OutputTruncated = true
+		result.OutputBytes = collector.TotalBytes()
+		result.OutputFile = collector.OutputFile()
+	}
+	return result, nil
+}
+
+func resolveShellPath() string {
+	value := strings.TrimSpace(os.Getenv("SHELL"))
+	if value != "" {
+		return value
+	}
+	return "/bin/sh"
+}
+
+func startIdleTimer(ctx context.Context, idleTimeout time.Duration, activity <-chan struct{}, onTimeout func()) func() {
+	if idleTimeout <= 0 {
+		return func() {}
+	}
+	timer := time.NewTimer(idleTimeout)
+	done := make(chan struct{})
+	stopped := make(chan struct{})
+	go func() {
+		defer close(stopped)
+		defer timer.Stop()
+		for {
+			select {
+			case <-activity:
+				if !timer.Stop() {
+					select {
+					case <-timer.C:
+					default:
+					}
+				}
+				timer.Reset(idleTimeout)
+			case <-timer.C:
+				onTimeout()
+				return
+			case <-ctx.Done():
+				return
+			case <-done:
+				return
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		<-stopped
+	}
+}
+
+func normalizePipeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, os.ErrClosed) {
+		return nil
+	}
+	return err
+}
+
+type streamWriter struct {
+	collector *outputCollector
+	stdout    bool
+	activity  func()
+}
+
+func (w *streamWriter) Write(p []byte) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	if w.activity != nil {
+		w.activity()
+	}
+	if w.stdout {
+		return w.collector.WriteStdout(p)
+	}
+	return w.collector.WriteStderr(p)
+}
+
+type outputCollector struct {
+	maxOutput  int
+	stdout     bytes.Buffer
+	stderr     bytes.Buffer
+	combined   bytes.Buffer
+	output     *os.File
+	outputPath string
+	totalBytes int
+	truncated  bool
+	mu         sync.Mutex
+}
+
+func newOutputCollector(maxOutput int) *outputCollector {
+	return &outputCollector{maxOutput: maxOutput}
+}
+
+func (o *outputCollector) WriteStdout(p []byte) (int, error) {
+	return o.write(p, &o.stdout)
+}
+
+func (o *outputCollector) WriteStderr(p []byte) (int, error) {
+	return o.write(p, &o.stderr)
+}
+
+func (o *outputCollector) write(p []byte, buffer *bytes.Buffer) (int, error) {
+	if len(p) == 0 {
+		return 0, nil
+	}
+	o.mu.Lock()
+	defer o.mu.Unlock()
+
+	if o.truncated {
+		o.totalBytes += len(p)
+		if o.output != nil {
+			if _, err := o.output.Write(p); err != nil {
+				return 0, err
+			}
+		}
+		return len(p), nil
+	}
+
+	if o.maxOutput <= 0 {
+		o.totalBytes += len(p)
+		_, _ = buffer.Write(p)
+		return len(p), nil
+	}
+
+	newTotal := o.totalBytes + len(p)
+	if newTotal > o.maxOutput {
+		allowed := o.maxOutput - o.totalBytes
+		file, err := os.CreateTemp(os.TempDir(), "agn-shell-output-")
+		if err != nil {
+			return 0, err
+		}
+		o.output = file
+		o.outputPath = file.Name()
+		if o.combined.Len() > 0 {
+			if _, err := o.output.Write(o.combined.Bytes()); err != nil {
+				return 0, err
+			}
+		}
+		if _, err := o.output.Write(p); err != nil {
+			return 0, err
+		}
+		if allowed > 0 {
+			_, _ = buffer.Write(p[:allowed])
+		}
+		o.totalBytes = newTotal
+		o.truncated = true
+		o.combined.Reset()
+		return len(p), nil
+	}
+
+	o.totalBytes = newTotal
+	_, _ = buffer.Write(p)
+	_, _ = o.combined.Write(p)
+	return len(p), nil
+}
+
+func (o *outputCollector) Stdout() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.stdout.String()
+}
+
+func (o *outputCollector) Stderr() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.stderr.String()
+}
+
+func (o *outputCollector) OutputFile() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.outputPath
+}
+
+func (o *outputCollector) TotalBytes() int {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.totalBytes
+}
+
+func (o *outputCollector) Truncated() bool {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.truncated
+}
+
+func (o *outputCollector) Close() error {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	if o.output != nil {
+		err := o.output.Close()
+		o.output = nil
+		return err
+	}
+	return nil
+}

--- a/internal/mcp/shell_test.go
+++ b/internal/mcp/shell_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -97,12 +98,89 @@ func TestShellToolTruncation(t *testing.T) {
 	t.Cleanup(func() {
 		_ = os.Remove(output.OutputFile)
 	})
-	require.Equal(t, os.TempDir(), filepath.Dir(output.OutputFile))
+	expectedTempDir, err := filepath.EvalSymlinks(os.TempDir())
+	require.NoError(t, err)
+	actualTempDir, err := filepath.EvalSymlinks(filepath.Dir(output.OutputFile))
+	require.NoError(t, err)
+	require.Equal(t, expectedTempDir, actualTempDir)
 	require.True(t, strings.HasPrefix(filepath.Base(output.OutputFile), "agn-shell-output-"))
 
 	data, err := os.ReadFile(output.OutputFile)
 	require.NoError(t, err)
 	require.Equal(t, "1234567890abc", string(data))
+}
+
+func TestParseShellArgumentsTimeoutCapping(t *testing.T) {
+	tests := []struct {
+		name            string
+		raw             string
+		cfg             ShellToolConfig
+		expectedTimeout time.Duration
+		expectedIdle    time.Duration
+		errContains     string
+	}{
+		{
+			name:            "per-call overrides defaults",
+			raw:             `{"command":"echo hi","timeout":2,"idle_timeout":4}`,
+			cfg:             ShellToolConfig{Timeout: 5, IdleTimeout: 3},
+			expectedTimeout: 2 * time.Second,
+			expectedIdle:    4 * time.Second,
+		},
+		{
+			name:            "timeout capped by max",
+			raw:             `{"command":"echo hi","timeout":10}`,
+			cfg:             ShellToolConfig{Timeout: 1, MaxTimeout: 3},
+			expectedTimeout: 3 * time.Second,
+			expectedIdle:    0,
+		},
+		{
+			name:            "timeout zero capped by max",
+			raw:             `{"command":"echo hi","timeout":0}`,
+			cfg:             ShellToolConfig{Timeout: 0, MaxTimeout: 4},
+			expectedTimeout: 4 * time.Second,
+			expectedIdle:    0,
+		},
+		{
+			name:            "idle timeout capped by max",
+			raw:             `{"command":"echo hi","idle_timeout":7}`,
+			cfg:             ShellToolConfig{IdleTimeout: 1, MaxIdleTimeout: 2},
+			expectedTimeout: 0,
+			expectedIdle:    2 * time.Second,
+		},
+		{
+			name:            "idle timeout zero capped by max",
+			raw:             `{"command":"echo hi","idle_timeout":0}`,
+			cfg:             ShellToolConfig{IdleTimeout: 0, MaxIdleTimeout: 3},
+			expectedTimeout: 0,
+			expectedIdle:    3 * time.Second,
+		},
+		{
+			name:        "missing command",
+			raw:         `{}`,
+			cfg:         ShellToolConfig{},
+			errContains: "shell command is required",
+		},
+		{
+			name:        "empty command",
+			raw:         `{"command":"   "}`,
+			cfg:         ShellToolConfig{},
+			errContains: "shell command is required",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, err := parseShellArguments(json.RawMessage(test.raw), test.cfg)
+			if test.errContains != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, test.errContains)
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, test.expectedTimeout, config.Timeout)
+			require.Equal(t, test.expectedIdle, config.IdleTimeout)
+		})
+	}
 }
 
 func decodeShellOutput(t *testing.T, result ToolResult) shellOutput {

--- a/internal/mcp/shell_test.go
+++ b/internal/mcp/shell_test.go
@@ -1,0 +1,117 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type shellOutput struct {
+	ExitCode        int    `json:"exit_code"`
+	Stdout          string `json:"stdout"`
+	Stderr          string `json:"stderr"`
+	OutputTruncated bool   `json:"output_truncated"`
+	OutputBytes     int    `json:"output_bytes"`
+	OutputFile      string `json:"output_file"`
+}
+
+func TestShellToolSuccess(t *testing.T) {
+	provider := NewShellToolProvider(ShellToolConfig{})
+	result, err := provider.CallTool(context.Background(), ToolCall{
+		Name:      ShellToolName,
+		Arguments: json.RawMessage(`{"command":"echo hello"}`),
+	})
+	require.NoError(t, err)
+
+	output := decodeShellOutput(t, result)
+	require.Equal(t, 0, output.ExitCode)
+	require.Equal(t, "hello\n", output.Stdout)
+	require.Equal(t, "", output.Stderr)
+}
+
+func TestShellToolNonZeroExit(t *testing.T) {
+	provider := NewShellToolProvider(ShellToolConfig{})
+	result, err := provider.CallTool(context.Background(), ToolCall{
+		Name:      ShellToolName,
+		Arguments: json.RawMessage(`{"command":"echo fail 1>&2; exit 3"}`),
+	})
+	require.NoError(t, err)
+
+	output := decodeShellOutput(t, result)
+	require.Equal(t, 3, output.ExitCode)
+	require.Equal(t, "", output.Stdout)
+	require.Equal(t, "fail\n", output.Stderr)
+}
+
+func TestShellToolCwd(t *testing.T) {
+	provider := NewShellToolProvider(ShellToolConfig{})
+	workdir := t.TempDir()
+	result, err := provider.CallTool(context.Background(), ToolCall{
+		Name:      ShellToolName,
+		Arguments: json.RawMessage(`{"command":"pwd","cwd":"` + workdir + `"}`),
+	})
+	require.NoError(t, err)
+
+	output := decodeShellOutput(t, result)
+	require.Equal(t, strings.TrimSpace(workdir), strings.TrimSpace(output.Stdout))
+}
+
+func TestShellToolTimeout(t *testing.T) {
+	provider := NewShellToolProvider(ShellToolConfig{Timeout: 1})
+	_, err := provider.CallTool(context.Background(), ToolCall{
+		Name:      ShellToolName,
+		Arguments: json.RawMessage(`{"command":"sleep 2"}`),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "timeout")
+}
+
+func TestShellToolIdleTimeout(t *testing.T) {
+	provider := NewShellToolProvider(ShellToolConfig{IdleTimeout: 1})
+	_, err := provider.CallTool(context.Background(), ToolCall{
+		Name:      ShellToolName,
+		Arguments: json.RawMessage(`{"command":"sleep 2","timeout":5}`),
+	})
+	require.Error(t, err)
+	require.ErrorContains(t, err, "idle timeout")
+}
+
+func TestShellToolTruncation(t *testing.T) {
+	provider := NewShellToolProvider(ShellToolConfig{MaxOutput: 10})
+	result, err := provider.CallTool(context.Background(), ToolCall{
+		Name:      ShellToolName,
+		Arguments: json.RawMessage(`{"command":"printf '1234567890abc'"}`),
+	})
+	require.NoError(t, err)
+
+	output := decodeShellOutput(t, result)
+	require.True(t, output.OutputTruncated)
+	require.Equal(t, 13, output.OutputBytes)
+	require.Equal(t, "1234567890", output.Stdout)
+	require.NotEmpty(t, output.OutputFile)
+	t.Cleanup(func() {
+		_ = os.Remove(output.OutputFile)
+	})
+	require.Equal(t, os.TempDir(), filepath.Dir(output.OutputFile))
+	require.True(t, strings.HasPrefix(filepath.Base(output.OutputFile), "agn-shell-output-"))
+
+	data, err := os.ReadFile(output.OutputFile)
+	require.NoError(t, err)
+	require.Equal(t, "1234567890abc", string(data))
+}
+
+func decodeShellOutput(t *testing.T, result ToolResult) shellOutput {
+	t.Helper()
+	require.Len(t, result.Content, 1)
+	item := result.Content[0]
+	require.Equal(t, ContentTypeText, item.Type)
+
+	var output shellOutput
+	require.NoError(t, json.Unmarshal([]byte(item.Text), &output))
+	return output
+}


### PR DESCRIPTION
## Summary
- add shell tool config defaults/validation and provider wiring
- implement built-in shell execution with timeouts, truncation, and reserved name checks
- add unit tests for config, tool injection, and shell execution scenarios

## Testing
- go test ./...
- go vet ./...
- go test -v -count=1 -tags e2e ./test/e2e/

Closes #55