### PR TITLE
Merge v0.3.5 fixes into main

### DIFF
--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -183,7 +182,7 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 		if mcpProvider != nil {
 			_ = mcpProvider.Close()
 		}
-		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), telemetry.FlushTimeout)
 		defer cancel()
 		_ = tracerProvider.Shutdown(shutdownCtx)
 	}

--- a/cmd/agn/main.go
+++ b/cmd/agn/main.go
@@ -50,7 +50,7 @@ func execCommand() *cobra.Command {
 				return err
 			}
 			maxSteps := resolveMaxSteps(cfg)
-			agent, _, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
+			agent, _, _, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
 			}
@@ -97,7 +97,7 @@ func execResumeCommand() *cobra.Command {
 				return err
 			}
 			maxSteps := resolveMaxSteps(cfg)
-			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
+			agent, store, _, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
 			}
@@ -153,12 +153,12 @@ func serveCommand() *cobra.Command {
 				return err
 			}
 			maxSteps := resolveMaxSteps(cfg)
-			agent, store, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
+			agent, store, flush, cleanup, err := buildAgent(cmd.Context(), cfg, maxSteps)
 			if err != nil {
 				return err
 			}
 			defer cleanup()
-			srv := server.New(agent, store)
+			srv := server.New(agent, store, flush)
 			return srv.Serve(cmd.Context(), cmd.InOrStdin(), cmd.OutOrStdout())
 		},
 	}
@@ -172,10 +172,10 @@ func resolveMaxSteps(cfg config.Config) int {
 	return loop.DefaultMaxSteps
 }
 
-func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Agent, state.Store, func(), error) {
+func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Agent, state.Store, func(context.Context) error, func(), error) {
 	tracerProvider, err := telemetry.Init(ctx)
 	if err != nil {
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 	tracer := tracerProvider.Tracer("agn")
 	var mcpProvider mcp.ToolProvider
@@ -191,19 +191,19 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 	apiKey, err := cfg.LLM.Auth.ResolveAPIKey()
 	if err != nil {
 		cleanup()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 	llmClient, err := llm.NewClient(cfg.LLM.Endpoint, apiKey, cfg.LLM.Model)
 	if err != nil {
 		cleanup()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 	summarizerClient := llmClient
 	if cfg.Summarization.LLM != nil {
 		summarizerKey, err := cfg.Summarization.LLM.Auth.ResolveAPIKey()
 		if err != nil {
 			cleanup()
-			return nil, nil, func() {}, err
+			return nil, nil, nil, func() {}, err
 		}
 		summarizerClient, err = llm.NewClient(
 			cfg.Summarization.LLM.Endpoint,
@@ -212,7 +212,7 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 		)
 		if err != nil {
 			cleanup()
-			return nil, nil, func() {}, err
+			return nil, nil, nil, func() {}, err
 		}
 	}
 	summarizer, err := summarize.New(summarizerClient, summarize.Config{
@@ -221,17 +221,17 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 	})
 	if err != nil {
 		cleanup()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 	store, err := state.NewDefaultLocalStore()
 	if err != nil {
 		cleanup()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 	mcpProvider, err = newToolProvider(ctx, cfg.Tools, cfg.MCP)
 	if err != nil {
 		cleanup()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 	agent, err := loop.NewAgent(loop.AgentConfig{
 		Store:        store,
@@ -244,9 +244,9 @@ func buildAgent(ctx context.Context, cfg config.Config, maxSteps int) (*loop.Age
 	})
 	if err != nil {
 		cleanup()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
-	return agent, store, cleanup, nil
+	return agent, store, tracerProvider.ForceFlush, cleanup, nil
 }
 
 func newToolProvider(ctx context.Context, toolsCfg config.ToolsConfig, mcpCfg config.MCPConfig) (mcp.ToolProvider, error) {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -61,6 +61,7 @@ func (c *Client) CreateResponse(
 	}
 	if len(tools) > 0 {
 		params.Tools = tools
+		params.ParallelToolCalls = openai.Bool(true)
 	}
 	if strings.TrimSpace(instructions) != "" {
 		params.Instructions = openai.String(strings.TrimSpace(instructions))

--- a/internal/loop/agent.go
+++ b/internal/loop/agent.go
@@ -25,6 +25,7 @@ import (
 const (
 	DefaultMaxSteps            = 1000
 	defaultMaxRestrictAttempts = 2
+	toolCallInstructions       = "If tool calls are needed, include all required tool calls in a single response."
 )
 
 type EventType string
@@ -75,6 +76,7 @@ type State struct {
 	LastAssistant      string
 	EventSink          EventSink
 	LoadedMessageCount int
+	LLMCallCount       int
 }
 
 type AgentConfig struct {
@@ -246,26 +248,23 @@ func (a *Agent) summarize(ctx context.Context, state *State) error {
 }
 
 func (a *Agent) callModel(ctx context.Context, state *State) error {
-	spanCtx, span := a.tracer.Start(ctx, "llm.call")
-	defer span.End()
-	span.SetAttributes(attribute.String("gen_ai.system", "openai"))
-
 	contextItems, err := a.buildContextItems(state)
 	if err != nil {
 		return err
 	}
 	contextMessages := make([]message.Message, 0, len(contextItems))
+	contextEvents := make([]contextEvent, 0, len(contextItems))
 	for _, item := range contextItems {
 		text, err := contextItemText(item.Message)
 		if err != nil {
 			return err
 		}
-		span.AddEvent("agyn.llm.context_item", trace.WithAttributes(
-			attribute.String("agyn.context.role", string(item.Message.Role())),
-			attribute.String("agyn.context.text", text),
-			attribute.String("agyn.context.is_new", strconv.FormatBool(item.IsNew)),
-			attribute.Int("agyn.context.size_bytes", len(text)),
-		))
+		contextEvents = append(contextEvents, contextEvent{
+			role:      string(item.Message.Role()),
+			text:      text,
+			isNew:     item.IsNew,
+			sizeBytes: len(text),
+		})
 		contextMessages = append(contextMessages, item.Message)
 	}
 	inputs, err := llm.MessagesToInput(contextMessages)
@@ -273,6 +272,9 @@ func (a *Agent) callModel(ctx context.Context, state *State) error {
 		return err
 	}
 	instructions := ""
+	if len(state.Tools) > 0 {
+		instructions = toolCallInstructions
+	}
 	toolChoice := responses.ResponseNewParamsToolChoiceUnion{}
 	if state.ForceToolCall {
 		toolChoice.OfToolChoiceMode = openai.Opt(responses.ToolChoiceOptionsRequired)
@@ -288,25 +290,21 @@ func (a *Agent) callModel(ctx context.Context, state *State) error {
 		}
 	}
 
-	response, err := a.llm.CreateResponse(spanCtx, instructions, inputs, state.Tools, toolChoice, state.Stream, onDelta)
+	callIndex := state.LLMCallCount
+	start := time.Now()
+	response, err := a.llm.CreateResponse(ctx, instructions, inputs, state.Tools, toolChoice, state.Stream, onDelta)
 	if err != nil {
+		if callIndex == 0 {
+			a.recordLLMSpan(ctx, start, time.Now(), contextEvents, nil, "")
+		}
+		state.LLMCallCount++
 		return err
 	}
 	text := strings.TrimSpace(response.OutputText())
-	span.SetAttributes(
-		attribute.String("gen_ai.request.model", response.Model),
-		attribute.String("gen_ai.response.finish_reason", string(response.Status)),
-		attribute.String("agyn.llm.response_text", text),
-	)
-	if response.JSON.Usage.Valid() {
-		span.SetAttributes(
-			attribute.Int64("gen_ai.usage.input_tokens", response.Usage.InputTokens),
-			attribute.Int64("gen_ai.usage.output_tokens", response.Usage.OutputTokens),
-			attribute.Int64("gen_ai.usage.cache_read.input_tokens", response.Usage.InputTokensDetails.CachedTokens),
-			attribute.Int64("agyn.usage.reasoning_tokens", response.Usage.OutputTokensDetails.ReasoningTokens),
-		)
-	}
 	toolCalls := llm.ExtractToolCalls(response)
+	if callIndex == 0 || text != "" {
+		a.recordLLMSpan(ctx, start, time.Now(), contextEvents, response, text)
+	}
 
 	if text == "" && len(toolCalls) == 0 {
 		return errors.New("model returned no content")
@@ -331,7 +329,44 @@ func (a *Agent) callModel(ctx context.Context, state *State) error {
 		state.PendingToolCalls = toolCalls
 	}
 	state.ForceToolCall = false
+	state.LLMCallCount++
 	return nil
+}
+
+func (a *Agent) recordLLMSpan(
+	ctx context.Context,
+	start time.Time,
+	end time.Time,
+	contextEvents []contextEvent,
+	response *responses.Response,
+	text string,
+) {
+	_, span := a.tracer.Start(ctx, "llm.call", trace.WithTimestamp(start))
+	span.SetAttributes(attribute.String("gen_ai.system", "openai"))
+	for _, event := range contextEvents {
+		span.AddEvent("agyn.llm.context_item", trace.WithAttributes(
+			attribute.String("agyn.context.role", event.role),
+			attribute.String("agyn.context.text", event.text),
+			attribute.String("agyn.context.is_new", strconv.FormatBool(event.isNew)),
+			attribute.Int("agyn.context.size_bytes", event.sizeBytes),
+		))
+	}
+	if response != nil {
+		span.SetAttributes(
+			attribute.String("gen_ai.request.model", response.Model),
+			attribute.String("gen_ai.response.finish_reason", string(response.Status)),
+			attribute.String("agyn.llm.response_text", text),
+		)
+		if response.JSON.Usage.Valid() {
+			span.SetAttributes(
+				attribute.Int64("gen_ai.usage.input_tokens", response.Usage.InputTokens),
+				attribute.Int64("gen_ai.usage.output_tokens", response.Usage.OutputTokens),
+				attribute.Int64("gen_ai.usage.cache_read.input_tokens", response.Usage.InputTokensDetails.CachedTokens),
+				attribute.Int64("agyn.usage.reasoning_tokens", response.Usage.OutputTokensDetails.ReasoningTokens),
+			)
+		}
+	}
+	span.End(trace.WithTimestamp(end))
 }
 
 func (a *Agent) route(ctx context.Context, state *State) (StageID, error) {
@@ -448,6 +483,13 @@ func (a *Agent) buildContextItems(state *State) ([]contextItem, error) {
 type contextItem struct {
 	Message message.Message
 	IsNew   bool
+}
+
+type contextEvent struct {
+	role      string
+	text      string
+	isNew     bool
+	sizeBytes int
 }
 
 func contextItemText(msg message.Message) (string, error) {

--- a/internal/loop/agent.go
+++ b/internal/loop/agent.go
@@ -291,6 +291,9 @@ func (a *Agent) callModel(ctx context.Context, state *State) error {
 	}
 
 	callIndex := state.LLMCallCount
+	// Record a span for the first LLM call (even on error) to capture context
+	// events. Subsequent calls only emit spans when they return assistant text,
+	// avoiding duplicated context events during tool-call loops.
 	start := time.Now()
 	response, err := a.llm.CreateResponse(ctx, instructions, inputs, state.Tools, toolChoice, state.Stream, onDelta)
 	if err != nil {

--- a/internal/loop/agent_trace_test.go
+++ b/internal/loop/agent_trace_test.go
@@ -1,0 +1,265 @@
+package loop
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+
+	"github.com/agynio/agn-cli/internal/llm"
+	"github.com/agynio/agn-cli/internal/message"
+	"github.com/agynio/agn-cli/internal/state"
+	"github.com/agynio/agn-cli/internal/summarize"
+)
+
+func TestCallModelSpanCoalescingFirstCallSuccess(t *testing.T) {
+	server, errCh := newLLMServer(t, []llmResponse{
+		{status: http.StatusOK, body: textResponseBody(t, "hello")},
+	})
+	client := newTestLLMClient(t, server.URL)
+	spanRecorder, agent := newTestAgent(t, client)
+	state := newTestState(t, agent)
+
+	err := agent.callModel(context.Background(), state)
+	require.NoError(t, err)
+	assertNoServerErrors(t, errCh)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "llm.call", spans[0].Name())
+}
+
+func TestCallModelSpanCoalescingFirstCallError(t *testing.T) {
+	body := errorResponseBody(t, "boom")
+	server, errCh := newLLMServer(t, []llmResponse{
+		{status: http.StatusInternalServerError, body: body},
+		{status: http.StatusInternalServerError, body: body},
+		{status: http.StatusInternalServerError, body: body},
+	})
+	client := newTestLLMClient(t, server.URL)
+	spanRecorder, agent := newTestAgent(t, client)
+	state := newTestState(t, agent)
+
+	err := agent.callModel(context.Background(), state)
+	require.Error(t, err)
+	assertNoServerErrors(t, errCh)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "llm.call", spans[0].Name())
+}
+
+func TestCallModelSpanCoalescingToolCallOnlySkipsSpan(t *testing.T) {
+	server, errCh := newLLMServer(t, []llmResponse{
+		{status: http.StatusOK, body: toolCallResponseBody(t, "call-1", "tool")},
+	})
+	client := newTestLLMClient(t, server.URL)
+	spanRecorder, agent := newTestAgent(t, client)
+	state := newTestState(t, agent)
+	state.LLMCallCount = 1
+
+	err := agent.callModel(context.Background(), state)
+	require.NoError(t, err)
+	assertNoServerErrors(t, errCh)
+
+	spans := spanRecorder.Ended()
+	require.Empty(t, spans)
+}
+
+func TestCallModelSpanCoalescingSubsequentTextRecordsSpan(t *testing.T) {
+	server, errCh := newLLMServer(t, []llmResponse{
+		{status: http.StatusOK, body: textResponseBody(t, "done")},
+	})
+	client := newTestLLMClient(t, server.URL)
+	spanRecorder, agent := newTestAgent(t, client)
+	state := newTestState(t, agent)
+	state.LLMCallCount = 1
+
+	err := agent.callModel(context.Background(), state)
+	require.NoError(t, err)
+	assertNoServerErrors(t, errCh)
+
+	spans := spanRecorder.Ended()
+	require.Len(t, spans, 1)
+	require.Equal(t, "llm.call", spans[0].Name())
+}
+
+type llmResponse struct {
+	status int
+	body   []byte
+}
+
+type llmServer struct {
+	mu        sync.Mutex
+	responses []llmResponse
+	index     int
+	errCh     chan error
+}
+
+func newLLMServer(t *testing.T, responses []llmResponse) (*httptest.Server, <-chan error) {
+	t.Helper()
+	serverState := &llmServer{responses: responses, errCh: make(chan error, 1)}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		serverState.recordUnexpected(r)
+		serverState.respond(w)
+	}))
+	t.Cleanup(server.Close)
+	return server, serverState.errCh
+}
+
+func (s *llmServer) recordUnexpected(r *http.Request) {
+	if r.Method != http.MethodPost {
+		s.recordError(fmt.Errorf("unexpected method %s", r.Method))
+	}
+	_, _ = io.Copy(io.Discard, r.Body)
+	_ = r.Body.Close()
+}
+
+func (s *llmServer) respond(w http.ResponseWriter) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.index >= len(s.responses) {
+		s.recordError(fmt.Errorf("unexpected llm request"))
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	resp := s.responses[s.index]
+	s.index++
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(resp.status)
+	_, _ = w.Write(resp.body)
+}
+
+func (s *llmServer) recordError(err error) {
+	select {
+	case s.errCh <- err:
+	default:
+	}
+}
+
+func assertNoServerErrors(t *testing.T, errCh <-chan error) {
+	t.Helper()
+	select {
+	case err := <-errCh:
+		require.NoError(t, err)
+	default:
+	}
+}
+
+type stubStore struct{}
+
+func (s stubStore) Load(ctx context.Context, threadID string) (state.Thread, error) {
+	return state.Thread{ID: threadID}, nil
+}
+
+func (s stubStore) Save(ctx context.Context, thread state.Thread) error {
+	return nil
+}
+
+func (s stubStore) List(ctx context.Context) ([]state.ThreadSummary, error) {
+	return nil, nil
+}
+
+func newTestLLMClient(t *testing.T, endpoint string) *llm.Client {
+	t.Helper()
+	client, err := llm.NewClient(endpoint, "test-key", "gpt-test")
+	require.NoError(t, err)
+	return client
+}
+
+func newTestAgent(t *testing.T, client *llm.Client) (*tracetest.SpanRecorder, *Agent) {
+	t.Helper()
+	spanRecorder := tracetest.NewSpanRecorder()
+	provider := sdktrace.NewTracerProvider(sdktrace.WithSpanProcessor(spanRecorder))
+	t.Cleanup(func() {
+		_ = provider.Shutdown(context.Background())
+	})
+	summarizer, err := summarize.New(client, summarize.Config{})
+	require.NoError(t, err)
+	agent, err := NewAgent(AgentConfig{
+		Store:      stubStore{},
+		LLM:        client,
+		Summarizer: summarizer,
+		MaxSteps:   1,
+		Tracer:     provider.Tracer("test"),
+	})
+	require.NoError(t, err)
+	return spanRecorder, agent
+}
+
+func newTestState(t *testing.T, agent *Agent) *State {
+	t.Helper()
+	record, err := agent.recordFromMessage("", message.NewHumanMessage("hello"))
+	require.NoError(t, err)
+	return &State{
+		Thread:             state.Thread{ID: "thread-1", Messages: []state.MessageRecord{record}},
+		TurnID:             "turn-1",
+		LoadedMessageCount: 1,
+	}
+}
+
+func textResponseBody(t *testing.T, text string) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]any{
+		"id":     "resp-1",
+		"model":  "gpt-test",
+		"status": "completed",
+		"output": []map[string]any{
+			{
+				"id":     "msg-1",
+				"type":   "message",
+				"role":   "assistant",
+				"status": "completed",
+				"content": []map[string]any{
+					{
+						"type":        "output_text",
+						"text":        text,
+						"annotations": []any{},
+					},
+				},
+			},
+		},
+	})
+}
+
+func toolCallResponseBody(t *testing.T, callID, name string) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]any{
+		"id":     "resp-2",
+		"model":  "gpt-test",
+		"status": "completed",
+		"output": []map[string]any{
+			{
+				"id":        callID,
+				"type":      "function_call",
+				"call_id":   callID,
+				"name":      name,
+				"arguments": "{\"foo\":\"bar\"}",
+			},
+		},
+	})
+}
+
+func errorResponseBody(t *testing.T, message string) []byte {
+	t.Helper()
+	return mustJSON(t, map[string]any{
+		"error": map[string]any{
+			"message": message,
+		},
+	})
+}
+
+func mustJSON(t *testing.T, payload any) []byte {
+	t.Helper()
+	data, err := json.Marshal(payload)
+	require.NoError(t, err)
+	return data
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -25,6 +25,7 @@ const (
 type Server struct {
 	agent    *loop.Agent
 	store    state.Store
+	flush    func(context.Context) error
 	writeMu  sync.Mutex
 	inFlight map[string]context.CancelFunc
 	mu       sync.Mutex
@@ -126,10 +127,11 @@ type ThreadResumeParams struct {
 	Stream         bool   `json:"stream,omitempty"`
 }
 
-func New(agent *loop.Agent, store state.Store) *Server {
+func New(agent *loop.Agent, store state.Store, flush func(context.Context) error) *Server {
 	return &Server{
 		agent:    agent,
 		store:    store,
+		flush:    flush,
 		inFlight: make(map[string]context.CancelFunc),
 	}
 }
@@ -381,12 +383,24 @@ func (s *Server) executeTurn(ctx context.Context, req request, writer io.Writer,
 		input.EventSink = s.eventSink(writer, idKey)
 	}
 	result, err := s.agent.Run(ctx, input)
+	s.flushSpans()
 	if err != nil {
 		s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Error: &rpcError{Code: -32603, Message: err.Error()}})
 		return
 	}
 
 	s.writeResponse(writer, response{JSONRPC: jsonRPCVersion, ID: req.ID, Result: TurnResult{ThreadID: result.ThreadID, Response: result.Response}})
+}
+
+func (s *Server) flushSpans() {
+	if s.flush == nil {
+		return
+	}
+	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := s.flush(flushCtx); err != nil {
+		fmt.Fprintf(os.Stderr, "agn server trace flush error: %v\n", err)
+	}
 }
 
 func (s *Server) eventSink(writer io.Writer, requestID string) loop.EventSink {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -14,6 +14,7 @@ import (
 	"github.com/agynio/agn-cli/internal/loop"
 	"github.com/agynio/agn-cli/internal/message"
 	"github.com/agynio/agn-cli/internal/state"
+	"github.com/agynio/agn-cli/internal/telemetry"
 )
 
 const (
@@ -393,10 +394,7 @@ func (s *Server) executeTurn(ctx context.Context, req request, writer io.Writer,
 }
 
 func (s *Server) flushSpans() {
-	if s.flush == nil {
-		return
-	}
-	flushCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	flushCtx, cancel := context.WithTimeout(context.Background(), telemetry.FlushTimeout)
 	defer cancel()
 	if err := s.flush(flushCtx); err != nil {
 		fmt.Fprintf(os.Stderr, "agn server trace flush error: %v\n", err)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,7 +88,7 @@ func runServerRequest(t *testing.T, input string) response {
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 	ctx, cancel := context.WithCancel(context.Background())
-	server := New(&loop.Agent{}, nil)
+	server := New(&loop.Agent{}, nil, nil)
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, inR, outW)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -88,7 +88,7 @@ func runServerRequest(t *testing.T, input string) response {
 	inR, inW := io.Pipe()
 	outR, outW := io.Pipe()
 	ctx, cancel := context.WithCancel(context.Background())
-	server := New(&loop.Agent{}, nil, nil)
+	server := New(&loop.Agent{}, nil, func(context.Context) error { return nil })
 	done := make(chan error, 1)
 	go func() {
 		done <- server.Serve(ctx, inR, outW)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"os"
 	"strings"
+	"time"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 )
+
+const FlushTimeout = 5 * time.Second
 
 func Init(ctx context.Context) (*sdktrace.TracerProvider, error) {
 	res, err := resource.New(


### PR DESCRIPTION
## Summary
- merge v0.3.5 tracing and tool-call fixes onto main
- flush tracing spans per turn in the JSON-RPC server
- coalesce LLM spans and enable parallel/batched tool calls
- ready for a v0.4.0 tag once approved (not tagged yet)

## Testing
- go test ./...
- go vet ./...

Relates to #132